### PR TITLE
reduce delay decoding rx audio after tx

### DIFF
--- a/ARDOPCommonCode/ALSASound.c
+++ b/ARDOPCommonCode/ALSASound.c
@@ -1112,21 +1112,7 @@ int OpenSoundCapture(char * CaptureDevice, int m_sampleRate, char * ErrorMsg)
 		return FALSE;
 	}
 
-//	Debugprintf("Capture using %d channels", m_recchannels);
-
-	int i;
-	short buf[256];
-
-	for (i = 0; i < 10; ++i)
-	{
-		if ((err = snd_pcm_readi (rechandle, buf, 128)) != 128)
-		{
-			Debugprintf("read from audio interface failed (%s)",
-				 snd_strerror (err));
-		}
-	}
-
-//	Debugprintf("Read got %d", err);
+	snd_pcm_start(rechandle);  // without this avail stuck at 0
 
  	return TRUE;
 }
@@ -1649,7 +1635,7 @@ void SoundFlush()
 	// samples sent is is in SampleNo, time started in mS is in pttOnTime.
 	// calculate time to stop
 
-	txlenMs = SampleNo / 12 + 200;		// 12000 samples per sec. 20 mS TXTAIL
+	txlenMs = SampleNo / 12 + 20;		// 12000 samples per sec. 20 mS TXTAIL
 
 	Debugprintf("Tx Time %d Time till end = %d", txlenMs, (pttOnTime + txlenMs) - Now);
 
@@ -1691,8 +1677,6 @@ void SoundFlush()
 	}
 */
 
-	OpenSoundCapture(SavedCaptureDevice, SavedCaptureRate, strFault);	
-
 	// I think we should turn round the link here. I dont see the point in
 	// waiting for MainPoll
 
@@ -1710,6 +1694,7 @@ void SoundFlush()
 
 	KeyPTT(FALSE);		 // Unkey the Transmitter
 
+	OpenSoundCapture(SavedCaptureDevice, SavedCaptureRate, strFault);
 	StartCapture();
 	return;
 }

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -2,7 +2,7 @@
 //	Code Common to all versions of ARDOP. 
 //
 
-const char ProductVersion[] = "2.0.3.2";
+const char ProductVersion[] = "2.0.3.2-pflarue-3";
 
 //	2.0.3.1 November 2023
 
@@ -14,6 +14,12 @@ const char ProductVersion[] = "2.0.3.2";
 //	Add Craig KM6LYW's snd_pcm_hw_params_set_period_size_near patch
 //	Set default TrailerLength to 20 (ms)
 //	Add --trailerlength command line parameter
+
+// 2.0.3.2-pflarue-3  December 2023
+
+// Modify SoundFlush() and OpenSoundCapture() to reduce delay decoding
+// received audio after transmitting.
+
 
 #ifdef WIN32
 #define _CRT_SECURE_NO_DEPRECATE


### PR DESCRIPTION
This fixes the problem of ptt being held on too long after TX such that the first part of the response is not heard and decoded.