### PR TITLE
Write rx wav

### DIFF
--- a/ARDOPC/Makefile
+++ b/ARDOPC/Makefile
@@ -2,7 +2,7 @@
 
 OBJS = ARDOPCommon.o LinSerial.o KISSModule.o pktARDOP.o pktSession.o BusyDetect.o i2cDisplay.o ALSASound.o \
 ARDOPC.o ardopSampleArrays.o ARQ.o FFT.o FEC.o HostInterface.o Modulate.o rs.o \
-berlekamp.o galois.o SoundInput.o TCPHostInterface.o SCSHostInterface.o
+berlekamp.o galois.o SoundInput.o TCPHostInterface.o SCSHostInterface.o wav.o
 
 # Configuration:
 CFLAGS = -DLINBPQ -MMD -g 

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -77,6 +77,7 @@ extern char PlaybackDevice[80];
 int extraDelay = 0;				// Used for long delay paths eg Satellite
 int	intARQDefaultDlyMs = 240;
 int TrailerLength = 20;
+BOOL WriteRxWav = FALSE;
 
 int PTTMode = PTTRTS;				// PTT Control Flags.
 
@@ -155,6 +156,7 @@ static struct option long_options[] =
 	{"extradelay",  required_argument, 0 , 'e'},
 	{"leaderlength",  required_argument, 0 , 'x'},
 	{"trailerlength",  required_argument, 0 , 't'},
+	{"writewav",  no_argument, 0, 'w'},
 	{"help",  no_argument, 0 , 'h'},
 	{ NULL , no_argument , NULL , no_argument }
 };
@@ -188,6 +190,7 @@ char HelpScreen[] =
 	"-e val or --extradelay val        Extend no response timeot for use on paths with long delay\n"
 	"--leaderlength val                Sets Leader Length (mS)\n"
 	"--trailerlength val               Sets Trailer Length (mS)\n"
+	"-w or --writewav                  Write WAV files of received audio for debugging.\n"
 	"\n"
 	" CAT and RTS PTT can share the same port.\n"
 	" See the ardop documentation for more information on cat and ptt options\n"
@@ -204,7 +207,7 @@ void processargs(int argc, char * argv[])
 	{		
 		int option_index = 0;
 
-		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytz", long_options, &option_index);
+		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytzw", long_options, &option_index);
 
 		// Check for end of operation or error
 		if (c == -1)
@@ -329,6 +332,10 @@ void processargs(int argc, char * argv[])
 
 		case 't':
 			TrailerLength = atoi(optarg);
+			break;
+
+		case 'w':
+			WriteRxWav = TRUE;
 			break;
 
 		case '?':

--- a/ARDOPCommonCode/ardopcommon.h
+++ b/ARDOPCommonCode/ardopcommon.h
@@ -111,6 +111,7 @@ typedef int BOOL;
 typedef unsigned char UCHAR;
 
 #define VOID void
+#define HANDLE int
 
 #define FALSE 0
 #define TRUE 1

--- a/ARDOPCommonCode/wav.c
+++ b/ARDOPCommonCode/wav.c
@@ -1,0 +1,79 @@
+// Write data to single channel 16-bit signed integer WAV file with a sample rate of 12000 Hz
+
+#include <stdio.h>
+#include <stdlib.h>
+#include "ardopcommon.h"
+#include "wav.h"
+
+// PCM WAV file header
+char WavHeader[] = {
+	0x52, 0x49, 0x46, 0x46, // "RIFF"
+	0x00, 0x00, 0x00, 0x00, // DUMMY file size - 8 in bytes = 2 * NumSamples + 36
+	0x57, 0x41, 0x56, 0x45, // "WAVE"
+	0x66, 0x6d, 0x74, 0x20, // "fmt "
+	0x10, 0x00, 0x00, 0x00, // Subchunk size = 16 for PCM
+	0x01, 0x00,             // WAVE type format
+	0x01, 0x00,             // single channel
+	0xE0, 0x2E, 0x00, 0x00, // sample rate = 12000 (Hz)
+	0xC0, 0x5D, 0x00, 0x00, // bytes/sec = 24000
+	0x02, 0x00,             // block alignment = (num channels * bitsPerChannel / 8) = 2
+	0x10, 0x00,             // bits per sample = 16
+	0x64, 0x61, 0x74, 0x61, // "data"
+	0x00, 0x00, 0x00, 0x00, // DUMMY data size in bytes = 2 * NumSamples for 16-bit samples
+};
+
+// Open a WAV for for writing.  Return NULL on failure.
+struct WavFile* OpenWavW(const char *pathname)
+{
+	WriteDebugLog(LOGDEBUG, "Opening WAV file for writing: %s", pathname);
+	struct WavFile *wf = (struct WavFile *) malloc(sizeof(struct WavFile));
+	if (wf == NULL)
+	{
+		WriteDebugLog(LOGDEBUG, "Unable to allocate WavFile struct.");
+		return NULL;
+	}
+		
+	wf->f = fopen(pathname, "wb");
+	if (wf->f == NULL)
+	{
+		WriteDebugLog(LOGDEBUG, "Unable to open WAV file.");
+		return NULL;
+	}
+		
+	wf->NumSamples = 0;
+	
+	// Write the header for the WAV file.  Use dummy values of 0 for size of file and size of chunk.
+	fwrite(WavHeader, 1, sizeof(WavHeader), wf->f);
+	return wf;
+}
+
+// Close a WAV file after updating the file header
+// If ardop is stopped while wf is open, then these required updates will not
+// be done, and the WAV file will not be valid.  However, using only the file
+// size, they can be fixed later.
+int CloseWav(struct WavFile *wf)
+{
+	int value;
+	int retval;
+	
+	WriteDebugLog(LOGDEBUG, "Finalizing and closing WAV file.");
+	// file length should be 44 + 2*wf->NumSamples
+	fseek(wf->f, 4, SEEK_SET);
+	value = 2 * wf->NumSamples + 36; 
+	fwrite(&value, 1, 4, wf->f);
+	fseek(wf->f, 40, SEEK_SET);
+	value = 2 * wf->NumSamples;
+	fwrite(&value, 1, 4, wf->f);
+	retval = fclose(wf->f);
+	free(wf);
+	return retval;
+}
+
+// Write data to an open WAV file
+int WriteWav(short *ptr, int num, struct WavFile *wf)
+{
+	// num is the number of 16-bit signed integers from ptr to be written
+	fwrite(ptr, 2, num, wf->f);
+	wf->NumSamples += num;
+	return (num * 2);
+}

--- a/ARDOPCommonCode/wav.h
+++ b/ARDOPCommonCode/wav.h
@@ -1,0 +1,16 @@
+#include <stdio.h>
+
+struct WavFile 
+{
+	FILE *f;
+	int NumSamples;
+};
+
+// Open a WAV for for writing.  Return NULL on failure.
+struct WavFile* OpenWavW(const char *pathname);
+
+// Close a WAV file after updating the file header
+int CloseWav(struct WavFile *wf);
+
+// Write data to WAV file
+int WriteWav(short *ptr, int num, struct WavFile *wf);


### PR DESCRIPTION
Add -w argument ardopc to write audio received after transmitting to a WAV file.  

A new audio file is opened after end of a transmission, and remains open for 10 seconds.  If another transmission ends before 10 seconds elapses, then keep the file open for 10 seconds from then, and so on.  This is intended to capture all of the received audio for a connection into one file.  No data is added to the file during transmission, only while receiving.  Files are written to the log path if specified, else to the current directory.  The port, date, and time are included in the filename.

This allows samples of received audio to be collected for debugging purposes.