### PR TITLE
Use value from DRIVELEVEL host command to reduce output level.

### DIFF
--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -14,6 +14,7 @@ FILE * fp1;
 // Function to generate the Two-tone leader and Frame Sync (used in all frame types) 
 
 extern short Dummy;
+extern int DriveLevel;
 
 int intSoftClipCnt = 0;
 
@@ -1158,6 +1159,8 @@ void SampleSink(short Sample)
 	int intFilLen = intN / 2;
 	int j;
 	float intFilteredSample = 0;			//  Filtered sample
+
+	Sample = Sample * DriveLevel / 100;
 
 	//	We save the previous intN samples
 	//	The samples are held in a cyclic buffer


### PR DESCRIPTION
Previously the DRIVELEVEL host command set a variable, but this variable was not used for anything.  This feature uses the value, which must be an integer between 0 and 100, to linearly scale the amplitude of the transmitted audio.  This variable is set to 100 if no DRIVELEVEL host command has been received, and this produces the same audio amplitude that was used prior to implementing this feature.  Thus, the drive level defaults to maximum, but can be reduced with a host command.