### PR TITLE
Added -n argument to send 5 second twotone signal and exit.

### DIFF
--- a/ARDOPCommonCode/ALSASound.c
+++ b/ARDOPCommonCode/ALSASound.c
@@ -48,6 +48,7 @@ int PackSamplesAndSend(short * input, int nSamples);
 void displayLevel(int max);
 BOOL WriteCOMBlock(HANDLE fd, char * Block, int BytesToWrite);
 VOID processargs(int argc, char * argv[]);
+void Send5SecTwoTone();
 
 int initdisplay();
 
@@ -69,6 +70,7 @@ BOOL UseLeftTX = TRUE;
 BOOL UseRightTX = TRUE;
 
 extern BOOL WriteRxWav;
+extern BOOL TwoToneAndExit;
 
 char LogDir[256] = "";
 
@@ -593,6 +595,14 @@ void main(int argc, char * argv[])
 
 	if (sigaction(SIGPIPE, &act, NULL) < 0) 
 		perror ("SIGPIPE");
+
+	if (TwoToneAndExit)
+	{
+		InitSound();
+		WriteDebugLog(LOGINFO, "Sending a 5 second 2-tone signal. Then exiting ardop.");
+		Send5SecTwoTone();
+		return;
+	}
 
 	ardopmain();
 

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -78,6 +78,7 @@ int extraDelay = 0;				// Used for long delay paths eg Satellite
 int	intARQDefaultDlyMs = 240;
 int TrailerLength = 20;
 BOOL WriteRxWav = FALSE;
+BOOL TwoToneAndExit = FALSE;
 
 int PTTMode = PTTRTS;				// PTT Control Flags.
 
@@ -157,6 +158,7 @@ static struct option long_options[] =
 	{"leaderlength",  required_argument, 0 , 'x'},
 	{"trailerlength",  required_argument, 0 , 't'},
 	{"writewav",  no_argument, 0, 'w'},
+	{"twotone", no_argument, 0, 'n'},
 	{"help",  no_argument, 0 , 'h'},
 	{ NULL , no_argument , NULL , no_argument }
 };
@@ -191,6 +193,7 @@ char HelpScreen[] =
 	"--leaderlength val                Sets Leader Length (mS)\n"
 	"--trailerlength val               Sets Trailer Length (mS)\n"
 	"-w or --writewav                  Write WAV files of received audio for debugging.\n"
+	"-n or --twotone                   Send a 5 second two tone signal and exit.\n"
 	"\n"
 	" CAT and RTS PTT can share the same port.\n"
 	" See the ardop documentation for more information on cat and ptt options\n"
@@ -207,7 +210,7 @@ void processargs(int argc, char * argv[])
 	{		
 		int option_index = 0;
 
-		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytzw", long_options, &option_index);
+		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytzwn", long_options, &option_index);
 
 		// Check for end of operation or error
 		if (c == -1)
@@ -336,6 +339,10 @@ void processargs(int argc, char * argv[])
 
 		case 'w':
 			WriteRxWav = TRUE;
+			break;
+
+		case 'n':
+			TwoToneAndExit = TRUE;
 			break;
 
 		case '?':


### PR DESCRIPTION
While ardopc will send a 5 second two tone test signal in response to a TWOTONETEST command received from a host, this may be inconvenient or not supported by some hosts.  So, using this -n command line argument provides an easy way to produce that same signal and then exit.  This can be run prior to starting ardopc normally to verify that everything is configured correctly.