### PR TITLE
Add demoduated 4FSK toned to debug log

### DIFF
--- a/ARDOPC/ARDOPC.c
+++ b/ARDOPC/ARDOPC.c
@@ -111,7 +111,7 @@ BOOL Use600Modes = FALSE;
 BOOL FSKOnly = FALSE;
 BOOL fastStart = TRUE;
 BOOL ConsoleLogLevel = LOGDEBUG;
-BOOL FileLogLevel = LOGDEBUG;
+BOOL FileLogLevel = LOGDEBUGPLUS;
 BOOL EnablePingAck = TRUE;
 
 BOOL gotGPIO = FALSE;

--- a/ARDOPC/ARDOPC.h
+++ b/ARDOPC/ARDOPC.h
@@ -61,6 +61,7 @@ extern unsigned int pttOnTime;
 #define LOGNOTICE 5
 #define LOGINFO 6
 #define LOGDEBUG 7
+#define LOGDEBUGPLUS 8
 
 #include <time.h>
 

--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -228,6 +228,8 @@ Reenter:
 			intDataPtr += 1;
 		}
 		// Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+		if (intDataBytesPerCar == 0)
+			sprintf(DebugMess + strlen(DebugMess), "(None)");
 		WriteDebugLog(LOGDEBUGPLUS, "%s", DebugMess);
 
 		if (Type == PktFrameHeader)

--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -55,6 +55,7 @@ void SendLeaderAndSYNC(UCHAR * bytEncodedBytes, int intLeaderLen)
 	UCHAR bytMask;
 	UCHAR bytSymToSend;
 	short intSample;
+	char DebugMess[256];
 	if (intLeaderLen == 0)
 		intLeaderLenMS = LeaderLength;
 	else
@@ -69,6 +70,7 @@ void SendLeaderAndSYNC(UCHAR * bytEncodedBytes, int intLeaderLen)
 
 	// note revised To accomodate 1 parity symbol per byte (10 symbols total)
 
+	sprintf(DebugMess, "LeaderAndSYNC tones : ");
 	for(j = 0; j < 2; j++)		 // for the 2 bytes of the frame type
 	{              
 		bytMask = 0xc0;
@@ -79,6 +81,7 @@ void SendLeaderAndSYNC(UCHAR * bytEncodedBytes, int intLeaderLen)
 				bytSymToSend = (bytMask & bytEncodedBytes[j]) >> (2 * (3 - k));
 			else
 				bytSymToSend = ComputeTypeParity(bytEncodedBytes[0]);
+			sprintf(DebugMess + strlen(DebugMess), "%d", bytSymToSend);
 
 			for(n = 0; n < 240; n++)
 			{
@@ -92,6 +95,8 @@ void SendLeaderAndSYNC(UCHAR * bytEncodedBytes, int intLeaderLen)
 			bytMask = bytMask >> 2;
 		}
 	}
+	// Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+	WriteDebugLog(LOGDEBUGPLUS, "%s", DebugMess);
 }
 
 
@@ -109,6 +114,7 @@ void Mod4FSKDataAndPlay(int Type, unsigned char * bytEncodedBytes, int Len, int 
 
     char strType[18] = "";
     char strMod[16] = "";
+    char DebugMess[1024];
 
 	UCHAR bytSymToSend, bytMask, bytMinQualThresh;
 
@@ -185,13 +191,15 @@ Reenter:
 		
 		dblCarScalingFactor = 1.0; //  (scaling factors determined emperically to minimize crest factor) 
 
+		sprintf(DebugMess, "Mod4FSKDataAndPlay 1Car tones :");
 		for (m = 0; m < intDataBytesPerCar; m++)  // For each byte of input data
 		{
 			bytMask = 0xC0;		 // Initialize mask each new data byte
-			
+			sprintf(DebugMess + strlen(DebugMess), " ");
 			for (k = 0; k < 4; k++)		// for 4 symbol values per byte of data
 			{
 				bytSymToSend = (bytMask & bytEncodedBytes[intDataPtr]) >> (2 * (3 - k)); // Values 0-3
+				sprintf(DebugMess + strlen(DebugMess), "%d", bytSymToSend);
 
 				for (n = 0; n < intSampPerSym; n++)	 // Sum for all the samples of a symbols 
 				{
@@ -219,6 +227,8 @@ Reenter:
 			}
 			intDataPtr += 1;
 		}
+		// Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+		WriteDebugLog(LOGDEBUGPLUS, "%s", DebugMess);
 
 		if (Type == PktFrameHeader)
 		{

--- a/ARDOPC/SoundInput.c
+++ b/ARDOPC/SoundInput.c
@@ -2088,6 +2088,8 @@ BOOL DemodFrameType4FSK(int intPtr, short * intSamples, int * intToneMags)
 {
 	float dblReal, dblImag;
 	int i;
+	int intMagSum;
+	UCHAR bytSym;
 
 	if ((intFilteredMixedSamplesLength - intPtr) < 2400)
 		return FALSE;
@@ -2105,8 +2107,22 @@ BOOL DemodFrameType4FSK(int intPtr, short * intSamples, int * intToneMags)
 		GoertzelRealImag(intSamples, intPtr, 240, 1425 / 50.0f, &dblReal, &dblImag);
 		intToneMags[3 + 4 * i] = (int)powf(dblReal, 2) + powf(dblImag, 2);
 		intPtr += 240;
+
+		// intMagSum and bytSym are used only to write tone values to debug log.
+		intMagSum = intToneMags[4 * i] + intToneMags[1 + 4 * i] + intToneMags[2 + 4 * i] + intToneMags[3 + 4 * i];
+		if (intToneMags[4 * i] > intToneMags[1 + 4 * i] && intToneMags[4 * i] > intToneMags[2 + 4 * i] && intToneMags[4 * i] > intToneMags[3 + 4 * i])
+			bytSym = 0;
+		else if (intToneMags[1 + 4 * i] > intToneMags[4 * i] && intToneMags[1 + 4 * i] > intToneMags[2 + 4 * i] && intToneMags[1 + 4 * i] > intToneMags[3 + 4 * i])
+			bytSym = 1;
+		else if (intToneMags[2 + 4 * i] > intToneMags[4 * i] && intToneMags[2 + 4 * i] > intToneMags[1 + 4 * i] && intToneMags[2 + 4 * i] > intToneMags[3 + 4 * i])
+			bytSym = 2;
+		else
+			bytSym = 3;
+
+	    // Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+		WriteDebugLog(LOGDEBUGPLUS, "FrameType_bytSym : %d(%d %03.0f/%03.0f/%03.0f/%03.0f)", bytSym, intMagSum, 100.0*intToneMags[4 * i]/intMagSum, 100.0*intToneMags[1 + 4 * i]/intMagSum, 100.0*intToneMags[2 + 4 * i]/intMagSum, 100.0*intToneMags[3 + 4 * i]/intMagSum);
 	}
-	
+
 	return TRUE;
 }
 

--- a/ARDOPC/SoundInput.c
+++ b/ARDOPC/SoundInput.c
@@ -2550,6 +2550,7 @@ void Demod1Car4FSKChar(int Start, UCHAR * Decoded, int Carrier)
 	static UCHAR bytSymHistory[3];
 	int j;
 	UCHAR bytData = 0;
+	char DebugMess[1024];
 
 	int * intToneMagsptr = &intToneMags[Carrier][intToneMagsIndex[Carrier]];
 	   
@@ -2561,7 +2562,7 @@ void Demod1Car4FSKChar(int Start, UCHAR * Decoded, int Carrier)
 	dblSearchFreq = intCenterFreq + (1.5f * intBaud);	// the highest freq (equiv to lowest sent freq because of sideband reversal)
 
 	// Do one symbol
-
+	sprintf(DebugMess, "4FSK_bytSym :");
 	for (j = 0; j < 4; j++)		// for each 4FSK symbol (2 bits) in a byte
 	{
 		dblMagSum = 0;
@@ -2590,6 +2591,7 @@ void Demod1Car4FSKChar(int Start, UCHAR * Decoded, int Carrier)
 		else
 			bytSym = 3;
 
+		sprintf(DebugMess + strlen(DebugMess), " %d(%.0f %03.0f/%03.0f/%03.0f/%03.0f)", bytSym, dblMagSum, 100*dblMag[0]/dblMagSum, 100*dblMag[1]/dblMagSum, 100*dblMag[2]/dblMagSum, 100*dblMag[3]/dblMagSum);
 		bytData = (bytData << 2) + bytSym;
 
 		// !!!!!!! this needs attention !!!!!!!!
@@ -2612,6 +2614,8 @@ void Demod1Car4FSKChar(int Start, UCHAR * Decoded, int Carrier)
 		Start += intSampPerSym; // advance the pointer one symbol
 	}
 
+    // Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+	WriteDebugLog(LOGDEBUGPLUS, "%s", DebugMess);
 	if (AccumulateStats)
 		intFSKSymbolCnt += 4;
  

--- a/ARDOPCommonCode/ALSASound.c
+++ b/ARDOPCommonCode/ALSASound.c
@@ -225,7 +225,8 @@ VOID WriteDebugLog(int Level, const char * format, ...)
 	if (!DebugLog)
 		return;
 
-	WriteLog(Mess, DEBUGLOG);
+	if (Level <= FileLogLevel)
+		WriteLog(Mess, DEBUGLOG);
 	return;
 }
 

--- a/ARDOPCommonCode/ardopcommon.h
+++ b/ARDOPCommonCode/ardopcommon.h
@@ -44,6 +44,7 @@ unsigned int getTicks();
 #define LOGNOTICE 5
 #define LOGINFO 6
 #define LOGDEBUG 7
+#define LOGDEBUGPLUS 8
 
 #include <time.h>
 


### PR DESCRIPTION
For deeper debugging purposes, write individual 1 carrier 4FSK tones sent and received to the debug log, including the tones used for Frame Type.  Since this is a more detailed level of debugging data than most might be interested in, a new log level of LOGDEBUGPLUS is defined and FileLogLevel is set to this in ARDOPC/ARDOPC.c.  ConsoleLogLevel remains set to LOGDEBUG so that this additional information is not printed to the console screen.  Changing FileLogLevel back to LOGDEBUG as it was previously, and then recompiling will disable logging of these tone values.

In addition to writing the received demodulated tone values, the relative magnitudes of the four candidates are also written to the log.  This allows the level of uncertainty for each tone to be determined from the log.

When logs from both the sending and receiving stations are available, comparison of these logs can provide insight into why certain frames failed to decode correctly.  If the log from the sending station is not available, but a recording of the received audio is available in addition to the log from the receiving station, then comparing the logged tone values to a spectrogram of the audio recording may be able to provide similar insight.