### PR TITLE
For mingw32 (ardopc)

### DIFF
--- a/ARDOPC/ARDOPC.c
+++ b/ARDOPC/ARDOPC.c
@@ -624,13 +624,6 @@ char * strlop(char * buf, char delim)
 	return ptr;
 }
 
-#ifdef WIN32
-float round(float x)
-{
-	return floorf(x + 0.5f);
-}
-#endif
-
 void GetSemaphore()
 {
 }

--- a/ARDOPC/ARDOPC.h
+++ b/ARDOPC/ARDOPC.h
@@ -37,7 +37,6 @@ extern const char ProductVersion[];
 #endif
 
 #ifdef WIN32
-float round(float x);
 typedef void *HANDLE;
 #else
 #define HANDLE int

--- a/ARDOPC/Makefile_mingw32
+++ b/ARDOPC/Makefile_mingw32
@@ -1,0 +1,25 @@
+#	ARDOPC Makefile for mingw32-make.exe from winlibs Intel/AMD 32-bit 
+
+OBJS = ARDOPCommon.o WinSerial.o KISSModule.o pktARDOP.o pktSession.o BusyDetect.o Waveout.o \
+ARDOPC.o ardopSampleArrays.o ARQ.o FFT.o FEC.o HostInterface.o Modulate.o rs.o \
+berlekamp.o galois.o SoundInput.o TCPHostInterface.o SCSHostInterface.o hid.o wav.o
+
+# Configuration:
+CFLAGS = -DLINBPQ -MMD -g 
+CC = gcc
+
+vpath %.c ../ARDOPCommonCode
+vpath %.h ../ARDOPCommonCode
+vpath %.o ./
+			                       
+all: ardopc
+			
+ardopc: $(OBJS)
+	gcc $(OBJS) -Xlinker -Map=output.map -lm -lpthread -lwsock32 -lwinmm -lsetupapi -o ardopc
+
+
+-include *.d
+
+clean :
+	del ardopc $(OBJS)
+

--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -1,5 +1,11 @@
 //	Sample Creation routines (encode and filter) for ARDOP Modem
 
+#ifdef WIN32
+#define _CRT_SECURE_NO_DEPRECATE
+#define _USE_32BIT_TIME_T
+#include <windows.h>
+#endif
+
 #include "ARDOPC.h"
 
 

--- a/ARDOPC/SoundInput.c
+++ b/ARDOPC/SoundInput.c
@@ -1,5 +1,11 @@
 //	ARDOP Modem Decode Sound Samples
 
+#ifdef WIN32
+#define _CRT_SECURE_NO_DEPRECATE
+#define _USE_32BIT_TIME_T
+#include <windows.h>
+#endif
+
 #include "ARDOPC.h"
 
 #pragma warning(disable : 4244)		// Code does lots of float to int
@@ -27,9 +33,6 @@
 #define PKTLED LED3		// flash when packet received
 extern unsigned int PKTLEDTimer;
 #endif
-
-//#define max(x, y) ((x) > (y) ? (x) : (y))
-//#define min(x, y) ((x) < (y) ? (x) : (y))
 
 void SendFrametoHost(unsigned char *data, unsigned dlen);
 

--- a/ARDOPC/WinSerial.c
+++ b/ARDOPC/WinSerial.c
@@ -30,7 +30,7 @@ extern BOOL UseKISS;			// Enable Packet (KISS) interface
 int Speed;
 int PollDelay;
 
-SOCKET PktSock;
+extern SOCKET PktSock;
 extern SOCKET PktListenSock;
 
 extern BOOL PKTCONNECTED;
@@ -130,8 +130,6 @@ extern volatile int RXBPtr;
 #define DebugWaitCompletion 4
 #define DebugReadCompletion 8
 */
-
-HANDLE hControl;
 
 typedef struct _SERIAL_STATUS {
     unsigned long Errors;

--- a/ARDOPC/WinSerial.c
+++ b/ARDOPC/WinSerial.c
@@ -19,7 +19,7 @@
 #include "ARDOPC.h"
 
 VOID ProcessSCSPacket(UCHAR * rxbuffer, int Length);
-WriteCOMBlock(hDevice, Message, MsgLen);
+BOOL WriteCOMBlock(HANDLE fd, char * Block, int BytesToWrite);
 int ReadCOMBlock(HANDLE fd, char * Block, int MaxLength);
 VOID ProcessKISSBytes(UCHAR * RXBuffer, int Read);
 void KISSTCPPoll();
@@ -217,7 +217,7 @@ int BPQSerialGetData(UCHAR * Message, unsigned int BufLen, unsigned long * MsgLe
 {
 	DWORD dwLength = 0;
 	DWORD Available = 0;
-	int Length, RealLen = 0;
+	long unsigned int Length, RealLen = 0;
 	
 	int ret = PeekNamedPipe(hDevice, NULL, 0, NULL, &Available, NULL);
 
@@ -296,7 +296,7 @@ BOOL SerialHostInit()
 {
 	WSADATA WsaData;			 // receives data from WSAStartup
 	unsigned long OpenCount = 0;
-	unsigned int Errorval;
+	long unsigned int Errorval;
 	char * Baud = strlop(PORTNAME, ',');
 
 	VCOM = TRUE;

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -518,7 +518,7 @@ int rawhid_recv(int num, void *buf, int len, int timeout)
 	unsigned char tmpbuf[516];
 	OVERLAPPED ov;
 	DWORD r;
-	int n;
+	long unsigned int n;
 
 	if (sizeof(tmpbuf) < len + 1) return -1;
 	hid = get_hid(num);
@@ -928,7 +928,7 @@ void DecodeCM108(char * ptr)
 	char product[256];
 
 	struct hid_device_info *devs, *cur_dev;
-	const char *path_to_open = NULL;
+	char *path_to_open = NULL;
 	hid_device *handle = NULL;
 
 	if (strlen(ptr) > 16)

--- a/ARDOPCommonCode/ardopcommon.h
+++ b/ARDOPCommonCode/ardopcommon.h
@@ -112,7 +112,11 @@ typedef int BOOL;
 typedef unsigned char UCHAR;
 
 #define VOID void
+#ifdef WIN32
+typedef void *HANDLE;
+#else
 #define HANDLE int
+#endif
 
 #define FALSE 0
 #define TRUE 1


### PR DESCRIPTION
Previously ardopc only had a Makefile for compiling on Linux.  This branch adds Makefile_mingw32 to compile on a Windows PC using winlibs Intel/AMD 32-bit (https://winlibs.com/).  It may also work for other Windows based c compiler systems, but this is the only one that has been tested at this time.  

Several minor changes to the source files were also required for ardopc to compile cleanly for Windows.