### PR TITLE
Add -W argument to decode WAV file instead of listening. (ardopc)

### DIFF
--- a/ARDOPCommonCode/ardopcommon.h
+++ b/ARDOPCommonCode/ardopcommon.h
@@ -229,6 +229,7 @@ BOOL GetNextFECFrame();
 void GenerateFSKTemplates();
 void printtick(char * msg);
 void InitValidFrameTypes();
+void setProtocolMode(char* strMode);
 //#endif
 
 extern void Generate50BaudTwoToneLeaderTemplate();
@@ -587,3 +588,6 @@ BOOL EncodeARQConRequest(char * strMyCallsign, char * strTargetCallsign, enum _A
 #define PTTHAMLIB	16
 
 #endif
+
+int decode_wav();
+


### PR DESCRIPTION
This commit allows ardopc to attempt to demodulate and decode the contents of a 16-bit signed integer 12kHz mono WAV audio recording, and then exit.  While processing the contents of such a recording, it uses the recently added RXO (receive only) ProtocolMode, thus attempting to decode all frames regardless of frame Type or SessionID.  It writes information about the decoded frames to the console and debug log file.  

The expected WAV file format matches that produced by the -w or --writewav option of ardopc, which records the received audio during an Ardop session.  Audio files from other sources may also be used.  If the parameters (mono vs stereo, sample rate, etc.) do not match, an error will be printed advising the user to consider using SoX to convert it.  This is a reference to https://sourceforge.net/projects/sox/, a multi-platform command line audio editing tool which can easily do such conversions.

This is intended primarily as a tool to facilitate development and debugging of routines for demodulating and decoding.  It allows different versions of ardopc, or the same version with different parameters, to process the same audio so that the output can be compared.  It also allows processing of modified versions of the same audio file.  As an example, this might be useful to test the impact of noise added to an audio recording using SoX or another tool.

Since the time markers in debug log files are not useful when decoding a WAV file, the log file also includes a reference to the approximate time offset from the start of the WAV file with each log message.