### PR TITLE
Write TX WAV files (ardopc)

### DIFF
--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -7,7 +7,7 @@
 #endif
 
 #include "ARDOPC.h"
-
+#include "../ARDOPCommonCode/wav.h"
 
 unsigned int pttOnTime;
 
@@ -21,9 +21,12 @@ FILE * fp1;
 
 extern short Dummy;
 extern int DriveLevel;
+extern BOOL WriteTxWav;
+extern struct WavFile *txwfu;
 
 int intSoftClipCnt = 0;
 
+void StartTxWav();
 void Flush();
 
 void GetTwoToneLeaderWithSync(int intSymLen)
@@ -1083,6 +1086,10 @@ unsigned short * SoundInit();
 void initFilter(int Width, int Centre)
 {
 	int i, j;
+
+	if (WriteTxWav)
+		StartTxWav();
+	
 	fWidth = Width;
 	centreSlot = Centre / 100;
 	largest = smallest = 0;
@@ -1179,7 +1186,9 @@ void SampleSink(short Sample)
 	float intFilteredSample = 0;			//  Filtered sample
 
 	Sample = Sample * DriveLevel / 100;
-
+	if (txwfu != NULL)
+		WriteWav(&Sample, 1, txwfu);
+	
 	//	We save the previous intN samples
 	//	The samples are held in a cyclic buffer
 

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -80,6 +80,7 @@ int	intARQDefaultDlyMs = 240;
 int TrailerLength = 20;
 BOOL InitRXO = FALSE;
 BOOL WriteRxWav = FALSE;
+BOOL WriteTxWav = FALSE;
 BOOL TwoToneAndExit = FALSE;
 BOOL UseSDFT = FALSE;
 char DecodeWav[256] = "";			// Pathname of WAV file to decode.
@@ -201,6 +202,7 @@ char HelpScreen[] =
 	"--trailerlength val                  Sets Trailer Length (mS)\n"
 	"-r or --receiveonly                  Start in RXO (receive only) mode.\n"
 	"-w or --writewav                     Write WAV files of received audio for debugging.\n"
+	"-T or --writetxwav                   Write WAV files of sent audio for debugging.\n"
 	"-W pathname or --decodewav pathname  Pathname of WAV file to decode instead of listening.\n"
 	"-n or --twotone                      Send a 5 second two tone signal and exit.\n"
 	"-s or --sdft                         Use the alternative Sliding DFT based 4FSK decoder.\n"
@@ -220,7 +222,7 @@ void processargs(int argc, char * argv[])
 	{		
 		int option_index = 0;
 
-		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytrzwW:ns", long_options, &option_index);
+		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytrzwTW:ns", long_options, &option_index);
 
 		// Check for end of operation or error
 		if (c == -1)
@@ -353,6 +355,10 @@ void processargs(int argc, char * argv[])
 
 		case 'w':
 			WriteRxWav = TRUE;
+			break;
+
+		case 'T':
+			WriteTxWav = TRUE;
 			break;
 
 		case 'W':


### PR DESCRIPTION
Add -T or --writetxwav argument to ardopc to write two 12kHz WAV audio files for each transmitted frame, one of the filtered audio and one of the unfiltered audio.  The audio files are written to the log path if specified, else to the current directory. The port, date, and time are included in the filename so that they can be easily associated with timestamps in the debug log file.  

This is intended for development and debugging purposes.  So, like the -w or --writewav arguments to write received audio to WAV files, this should not be activated for normal usage.  The files produced by both of these options have a size of about 12kB per second of audio.