### PR TITLE
Added -v/-V arguments to set console/file log levels (ardopc)

### DIFF
--- a/ARDOPC/ARDOPC.c
+++ b/ARDOPC/ARDOPC.c
@@ -110,8 +110,8 @@ BOOL AccumulateStats = TRUE;
 BOOL Use600Modes = FALSE;
 BOOL FSKOnly = FALSE;
 BOOL fastStart = TRUE;
-BOOL ConsoleLogLevel = LOGDEBUG;
-BOOL FileLogLevel = LOGDEBUGPLUS;
+int ConsoleLogLevel = LOGINFO;
+int FileLogLevel = LOGDEBUG;
 BOOL EnablePingAck = TRUE;
 
 BOOL gotGPIO = FALSE;
@@ -1936,7 +1936,7 @@ void SendID(BOOL blnEnableCWID)
 
 	p = bytEncodedBytes;
 
-	Debugprintf("%02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x ",
+	WriteDebugLog(LOGDEBUG, "%02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x ",
 		p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15], p[16], p[17]);
 
 
@@ -2353,7 +2353,7 @@ void CheckTimers()
 
 			//	Repeat mechanism for normal repeated FEC or ARQ frames
       
-			WriteDebugLog(LOGDEBUG, "Repeating Last Frame");
+			WriteDebugLog(LOGINFO, "[Repeating Last Frame]");
 			RemodulateLastFrame();
 		}
 		else

--- a/ARDOPC/ARQ.c
+++ b/ARDOPC/ARQ.c
@@ -356,6 +356,7 @@ BOOL GetNextARQFrame()
 		if (intRepeatCount > 5)  // do 5 tries then force disconnect 
 		{
 			QueueCommandToHost("DISCONNECTED");
+			WriteDebugLog(LOGINFO, "[STATUS: END NOT RECEIVED CLOSING ARQ SESSION WITH %s]", strRemoteCallsign);
 			sprintf(HostCmd, "STATUS END NOT RECEIVED CLOSING ARQ SESSION WITH %s", strRemoteCallsign);
 			QueueCommandToHost(HostCmd);
 			blnDISCRepeating = FALSE;
@@ -366,7 +367,7 @@ BOOL GetNextARQFrame()
 			InitializeConnection();
 			return FALSE;			 //indicates end repeat
 		}
-		WriteDebugLog(LOGDEBUG, "Repeating DISC %d", intRepeatCount);
+		WriteDebugLog(LOGINFO, "Repeating DISC %d", intRepeatCount);
 		EncLen = Encode4FSKControl(DISCFRAME, bytSessionID, bytEncodedBytes);
 
 		return TRUE;			// continue with DISC repeats
@@ -389,6 +390,7 @@ BOOL GetNextARQFrame()
 
 			if (strRemoteCallsign[0])
 			{
+				WriteDebugLog(LOGINFO, "[STATUS: CONNECT TO %s FAILED]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS CONNECT TO %s FAILED!", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
 				InitializeConnection();
@@ -396,6 +398,7 @@ BOOL GetNextARQFrame()
 			}
 			else
 			{
+				WriteDebugLog(LOGINFO, "[STATUS: END ARQ CALL]");
 				QueueCommandToHost("STATUS END ARQ CALL");
 				InitializeConnection();
 				return FALSE;		  //indicates end repeat
@@ -422,6 +425,7 @@ BOOL GetNextARQFrame()
 		{
 			SetARDOPProtocolState(DISC);
 			ARQState = DISCArqEnd;
+			WriteDebugLog(LOGINFO, "[STATUS: CONNECT TO %s FAILED]", strRemoteCallsign);
 			sprintf(HostCmd, "STATUS CONNECT TO %s FAILED!", strRemoteCallsign);
 			QueueCommandToHost(HostCmd);
 			intRepeatCount = 0;
@@ -1022,7 +1026,7 @@ void SendData()
 	{
 	case IDLE:
 
-		WriteDebugLog(LOGDEBUG, "[ARDOPProtocol.SendData] Sending Data from IDLE state! Exit SendData");
+		WriteDebugLog(LOGINFO, "[ARDOPProtocol.SendData] Sending Data from IDLE state! Exit SendData");
 		return;
 
 	case ISS:
@@ -1117,7 +1121,7 @@ void SendData()
 			EncLen = Encode4FSKControl(IDLEFRAME, bytSessionID, bytEncodedBytes);
 			Mod4FSKDataAndPlay(IDLEFRAME, &bytEncodedBytes[0], EncLen, LeaderLength);		// only returns when all sent
 	
-			WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.SendData]  Send IDLE with Repeat, Set ProtocolState=IDLE ");
+			WriteDebugLog(LOGINFO, "[ARDOPprotocol.SendData]  Send IDLE with Repeat, Set ProtocolState=IDLE ");
   			return;
 		}
 	}
@@ -1306,7 +1310,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 		{
 			// Special case to process DISC from previous connection (Ending station must have missed END reply to DISC) Handles protocol rule 1.5
     
-			WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame]  DISC frame received in ProtocolState DISC, Send END with SessionID= %XX Stay in DISC state", bytLastARQSessionID);
+			WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame]  DISC frame received in ProtocolState DISC, Send END with SessionID= %XX Stay in DISC state", bytLastARQSessionID);
 
 			EncLen = Encode4FSKControl(0x2C, bytLastARQSessionID, bytEncodedBytes);
 
@@ -1332,7 +1336,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 		strCallsign  = strlop(bytData, ' '); // "fromcall tocall"
 		strcpy(strRemoteCallsign, bytData);
 
-		WriteDebugLog(LOGDEBUG, "CONREQ From %s to %s Listen = %d", strRemoteCallsign, strCallsign, blnListen);
+		WriteDebugLog(LOGINFO, "CONREQ From %s to %s Listen = %d", strRemoteCallsign, strCallsign, blnListen);
 
 		if (!blnListen)
 			return;			 // ignore connect request if not blnListen
@@ -1357,7 +1361,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				if ((blnLeaderTrippedBusy && dttLastBusyClear - dttPriorLastBusyTrip < 600) 
 				|| (!blnLeaderTrippedBusy && dttLastBusyClear - dttLastBusyTrip < 600))
 				{
-					WriteDebugLog(LOGDEBUG, "[ProcessRcvdARQFrame] Con Req Blocked by BUSY!  LeaderTrippedBusy=%d, Prior Last Busy Trip=%d, Last Busy Clear=%d,  Last Leader Detect=%d",
+					WriteDebugLog(LOGINFO, "[ProcessRcvdARQFrame] Con Req Blocked by BUSY!  LeaderTrippedBusy=%d, Prior Last Busy Trip=%d, Last Busy Clear=%d,  Last Leader Detect=%d",
 						blnLeaderTrippedBusy, Now - dttPriorLastBusyTrip, Now - dttLastBusyClear, Now - dttLastLeaderDetect);
 
 					ClearBusy();
@@ -1370,6 +1374,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 					sprintf(HostCmd, "REJECTEDBUSY %s", strRemoteCallsign);
 					QueueCommandToHost(HostCmd);
+					WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION REQUEST FROM %s REJECTED, CHANNEL BUSY.]", strRemoteCallsign);
 					sprintf(HostCmd, "STATUS ARQ CONNECTION REQUEST FROM %s REJECTED, CHANNEL BUSY.", strRemoteCallsign);
 					QueueCommandToHost(HostCmd);
 
@@ -1420,6 +1425,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
              
 				sprintf(HostCmd, "REJECTEDBW %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION REJECTED BY %s]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION REJECTED BY %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
 			
@@ -1504,6 +1510,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
   					
 					sprintf(HostCmd, "REJECTEDBW %s", strRemoteCallsign);
 					QueueCommandToHost(HostCmd);
+					WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION FROM %s REJECTED, INCOMPATIBLE BANDWIDTHS.]", strRemoteCallsign);
 					sprintf(HostCmd, "STATUS ARQ CONNECTION FROM %s REJECTED, INCOMPATIBLE BANDWIDTHS.", strRemoteCallsign);
 					QueueCommandToHost(HostCmd);
 
@@ -1561,6 +1568,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				sprintf(HostCmd, "CONNECTED %s %d", strRemoteCallsign, intSessionBW);
 				QueueCommandToHost(HostCmd);
  
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION FROM %s: SESSION BW = %d HZ]", strRemoteCallsign, intSessionBW);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION FROM %s: SESSION BW = %d HZ", strRemoteCallsign, intSessionBW);
 				QueueCommandToHost(HostCmd);
 
@@ -1618,10 +1626,11 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 			if (blnFrameDecodedOK && intFrameType == DISCFRAME) //  IF DISC received from ISS Handles protocol rule 1.5
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame]  DISC frame received in ProtocolState IRS, IRSData...going to DISC state");
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame]  DISC frame received in ProtocolState IRS, IRSData...going to DISC state");
                 if (AccumulateStats) LogStats();
 				
 				QueueCommandToHost("DISCONNECTED");		// Send END
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION ENDED WITH %s]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION ENDED WITH %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
 				
@@ -1644,10 +1653,11 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 			
 			if (blnFrameDecodedOK && intFrameType == END) //  IF END received from ISS 
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame]  END frame received in ProtocolState IRS, IRSData...going to DISC state");
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame]  END frame received in ProtocolState IRS, IRSData...going to DISC state");
 				if (AccumulateStats) LogStats();
 				
 				QueueCommandToHost("DISCONNECTED");
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION ENDED WITH %s]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION ENDED WITH %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
 				blnDISCRepeating = FALSE;
@@ -1672,7 +1682,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 			
 			if (blnFrameDecodedOK && intFrameType == BREAK)
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame]  BREAK received in ProtocolState %s , IRSData. Sending ACK", ARDOPStates[ProtocolState]);
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame]  BREAK received in ProtocolState %s , IRSData. Sending ACK", ARDOPStates[ProtocolState]);
 
 				blnEnbARQRpt = FALSE; /// setup for no repeats
 
@@ -1686,7 +1696,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 			if (blnFrameDecodedOK && intFrameType == IDLEFRAME) //  IF IDLE received from ISS 
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame]  IDLE received in ProtocolState %s substate %s", ARDOPStates[ProtocolState], ARQSubStates[ARQState]);
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame]  IDLE received in ProtocolState %s substate %s", ARDOPStates[ProtocolState], ARQSubStates[ARQState]);
 				{
 					blnEnbARQRpt = FALSE; // setup for no repeats
 				
@@ -1699,6 +1709,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 						intFrameRepeatInterval = ComputeInterFrameInterval(1000 + rand() % 2000);
 
 						SetARDOPProtocolState(IRStoISS); // (ONLY IRS State where repeats are used)
+						WriteDebugLog(LOGINFO, "[STATUS: QUEUE BREAK new Protocol State IRStoISS]");
 						SendCommandToHost("STATUS QUEUE BREAK new Protocol State IRStoISS");
 						blnEnbARQRpt = TRUE;  // setup for repeats until changeover
  						EncLen = Encode4FSKControl(BREAK, bytSessionID, bytEncodedBytes);
@@ -1746,6 +1757,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 					blnEnbARQRpt = TRUE;  // setup for repeats until changeover
 					intFrameRepeatInterval = ComputeInterFrameInterval(1000 + rand() % 2000);
 					SetARDOPProtocolState(IRStoISS); // (ONLY IRS State where repeats are used)
+					WriteDebugLog(LOGINFO, "[STATUS: QUEUE BREAK new Protocol State IRStoISS]");
 					SendCommandToHost("STATUS QUEUE BREAK new Protocol State IRStoISS");
  					EncLen = Encode4FSKControl(BREAK, bytSessionID, bytEncodedBytes);
 					Mod4FSKDataAndPlay(BREAK, &bytEncodedBytes[0], EncLen, LeaderLength);		// only returns when all sent
@@ -1759,11 +1771,11 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 					dttTimeoutTrip = Now;
 				}
 				else
-                    WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] Frame with same Type - Discard");
+                    WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] Frame with same Type - Discard");
  				
 				if (ARQState == IRSfromISS)
 				{
-					WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] Data Rcvd in ProtocolState=IRSData, Substate IRSfromISS Go to Substate IRSData");
+					WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] Data Rcvd in ProtocolState=IRSData, Substate IRSfromISS Go to Substate IRSData");
 					ARQState = IRSData;   //This substate change is the final completion of ISS to IRS changeover and allows the new IRS to now break if desired (Rule 3.5) 
 				}
 			
@@ -1787,7 +1799,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				Mod4FSKDataAndPlay(bytEncodedBytes[0], &bytEncodedBytes[0], EncLen, LeaderLength);		// only returns when all sent
 				blnEnbARQRpt = FALSE;
 
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] Data Decode Failed but Frame Type matched last ACKed. Send ACK, data already passed to host. ");
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] Data Decode Failed but Frame Type matched last ACKed. Send ACK, data already passed to host. ");
 
 				// handles Data frame which did not decode correctly (Failed CRC) and hasn't been acked before
 			}
@@ -1795,7 +1807,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 			{
 				if (ARQState == IRSfromISS)
 				{
-					WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] Data Frame Type Rcvd in ProtocolState=IRSData, Substate IRSfromISS Go to Substate IRSData");
+					WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] Data Frame Type Rcvd in ProtocolState=IRSData, Substate IRSfromISS Go to Substate IRSData");
 
 					ARQState = IRSData;  //This substate change is the final completion of ISS to IRS changeover and allows the new IRS to now break if desired (Rule 3.5) 
 				}
@@ -1823,7 +1835,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 			if (intFrameType >= 0xE0 && bytDataToSendLength > 0)	 // If ACK and Data to send
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessedRcvdARQFrame] Protocol state IDLE, ACK Received with Data to send. Go to ISS Data state.");
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessedRcvdARQFrame] Protocol state IDLE, ACK Received with Data to send. Go to ISS Data state.");
 					
 				SetARDOPProtocolState(ISS);
 				ARQState = ISSData;
@@ -1842,7 +1854,8 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				EncLen = EncodeDATAACK(100, bytSessionID, bytEncodedBytes); // Send ACK
 				Mod4FSKDataAndPlay(bytEncodedBytes[0], &bytEncodedBytes[0], EncLen, LeaderLength);
 
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] BREAK Rcvd from IDLE, Go to IRS, Substate IRSfromISS");
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] BREAK Rcvd from IDLE, Go to IRS, Substate IRSfromISS");
+				WriteDebugLog(LOGINFO, "[STATUS: BREAK received from Protocol State IDLE, new state IRS]");
                 SendCommandToHost("STATUS BREAK received from Protocol State IDLE, new state IRS");
 				SetARDOPProtocolState(IRS);
 				//Substate IRSfromISS enables processing Rule 3.5 later
@@ -1856,11 +1869,12 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 			}
 			if (intFrameType == DISCFRAME) //  IF DISC received from IRS Handles protocol rule 1.5
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame]  DISC frame received Send END...go to DISC state");
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame]  DISC frame received Send END...go to DISC state");
                 
 				if (AccumulateStats) LogStats();
 					
 				QueueCommandToHost("DISCONNECTED");
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION ENDED WITH %s]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION ENDED WITH %s ", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
 				tmrFinalID = Now + 3000;
@@ -1875,9 +1889,10 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 			}
 			if (intFrameType == END)
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame]  END received ... going to DISC state");
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame]  END received ... going to DISC state");
 				if (AccumulateStats) LogStats();
 				QueueCommandToHost("DISCONNECTED");	
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION ENDED WITH %s]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION ENDED WITH %s ", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
 				ClearDataToSend();
@@ -1946,7 +1961,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				
 				intFrameRepeatInterval = 2000;
 				blnEnbARQRpt = TRUE;	// Setup for repeats of the ConACK if no answer from IRS
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] Compatible bandwidth received from IRS ConAck: %d Hz", intSessionBW);
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] Compatible bandwidth received from IRS ConAck: %d Hz", intSessionBW);
 				ARQState = ISSConAck;
 				dttLastFECIDSent = Now;
 
@@ -1958,9 +1973,10 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 			
 			if (intFrameType == ConRejBusy) // ConRejBusy Handles Protocol Rule 1.5
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] ConRejBusy received from %s ABORT Connect Request", strRemoteCallsign);
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] ConRejBusy received from %s ABORT Connect Request", strRemoteCallsign);
  				sprintf(HostCmd, "REJECTEDBUSY %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION REJECTED BY %s, REMOTE STATION BUSY.]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION REJECTED BY %s, REMOTE STATION BUSY.", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
 				Abort();
@@ -1968,9 +1984,10 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 			}
 			if (intFrameType == ConRejBW) // ConRejBW Handles Protocol Rule 1.3
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] ConRejBW received from %s ABORT Connect Request", strRemoteCallsign);
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] ConRejBW received from %s ABORT Connect Request", strRemoteCallsign);
  				sprintf(HostCmd, "REJECTEDBW %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION REJECTED BY %s, INCOMPATIBLE BW.]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION REJECTED BY %s, INCOMPATIBLE BW.", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
 				Abort();
@@ -1995,10 +2012,10 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				blnEnbARQRpt = FALSE;	// stop the repeats of ConAck and enables SendDataOrIDLE to get next IDLE or Data frame
 
 				if (intFrameType >= 0xE0 && DebugLog)
-					WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] ACK received in ARQState %s ", ARQSubStates[ARQState]);
+					WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] ACK received in ARQState %s ", ARQSubStates[ARQState]);
 
 				if (intFrameType == BREAK && DebugLog)
-					WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] BREAK received in ARQState %s Processed as implied ACK", ARQSubStates[ARQState]);
+					WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] BREAK received in ARQState %s Processed as implied ACK", ARQSubStates[ARQState]);
                                         
 				blnARQConnected = TRUE;
 				bytLastARQDataFrameAcked = 1; // initialize to Odd value to start transmission frame on Even
@@ -2006,6 +2023,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
    			
 				sprintf(HostCmd, "CONNECTED %s %d", strRemoteCallsign, intSessionBW);
 				QueueCommandToHost(HostCmd);
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION ESTABLISHED WITH %s, SESSION BW = %d HZ]", strRemoteCallsign, intSessionBW);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION ESTABLISHED WITH %s, SESSION BW = %d HZ", strRemoteCallsign, intSessionBW);
 				QueueCommandToHost(HostCmd);
 
@@ -2018,7 +2036,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				{
 					//' Initiate the transisiton to IRS
 	
-					WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] implied ACK, no data to send so action BREAK, send ACK");
+					WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] implied ACK, no data to send so action BREAK, send ACK");
 
 					ClearDataToSend();
 					blnEnbARQRpt = FALSE;  // setup for no repeats
@@ -2045,10 +2063,11 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 			if (blnFrameDecodedOK && intFrameType == ConRejBusy)  // ConRejBusy
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] ConRejBusy received in ARQState %s. Going to Protocol State DISC", ARQSubStates[ARQState]);
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] ConRejBusy received in ARQState %s. Going to Protocol State DISC", ARQSubStates[ARQState]);
 
 				sprintf(HostCmd, "REJECTEDBUSY %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION REJECTED BY %s]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION REJECTED BY %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
 
@@ -2062,6 +2081,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 				sprintf(HostCmd, "REJECTEDBW %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION REJECTED BY %s]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION REJECTED BY %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
 
@@ -2125,13 +2145,14 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 					sprintf(HostCmd, "CONNECTED %s %d", strRemoteCallsign, intSessionBW);
 					QueueCommandToHost(HostCmd);
+					WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION ESTABLISHED WITH %s, SESSION BW = %d HZ]", strRemoteCallsign, intSessionBW);
 					sprintf(HostCmd, "STATUS ARQ CONNECTION ESTABLISHED WITH %s, SESSION BW = %d HZ", strRemoteCallsign, intSessionBW);
 					QueueCommandToHost(HostCmd);
 				}
 				
 				//' Initiate the transisiton to IRS
 		
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame] BREAK Rcvd from ARQState ISSData, Go to ProtocolState IRS & substate IRSfromISS , send ACK");
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame] BREAK Rcvd from ARQState ISSData, Go to ProtocolState IRS & substate IRSfromISS , send ACK");
 
 				// With new rules IRS can use BREAK to interrupt data from ISS. It will only
 				// be sent on IDLE or changed data frame type, so we know the last sent data
@@ -2144,6 +2165,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				blnEnbARQRpt = FALSE;  // setup for no repeats
 				intTrackingQuality = -1; // 'initialize tracking quality to illegal value
 				intNAKctr = 0;
+				WriteDebugLog(LOGINFO, "[STATUS: BREAK received from Protocol State ISS, new state IRS]");
 				SendCommandToHost("STATUS BREAK received from Protocol State ISS, new state IRS");
 
 				// Send ACK
@@ -2187,10 +2209,11 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 			if (intFrameType == DISCFRAME) // if DISC  Handles protocol rule 1.5
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame]  DISC frame received Send END...go to DISC state");
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame]  DISC frame received Send END...go to DISC state");
 				if (AccumulateStats) LogStats();
 					
 				QueueCommandToHost("DISCONNECTED");
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION ENDED WITH %s]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION ENDED WITH %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
       
@@ -2209,10 +2232,11 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				
 			if (intFrameType == END)	// ' if END
 			{
-				WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessRcvdARQFrame]  END received ... going to DISC state");
+				WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessRcvdARQFrame]  END received ... going to DISC state");
 				if (AccumulateStats) LogStats();
 					
 				QueueCommandToHost("DISCONNECTED");
+				WriteDebugLog(LOGINFO, "[STATUS: ARQ CONNECTION ENDED WITH %s]", strRemoteCallsign);
 				sprintf(HostCmd, "STATUS ARQ CONNECTION ENDED WITH %s", strRemoteCallsign);
 				QueueCommandToHost(HostCmd);
 				ClearDataToSend();
@@ -2441,6 +2465,7 @@ BOOL CheckForDisconnect()
 	{
 		WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.CheckForDisconnect]  ARQ Disconnect ...Sending DISC (repeat)");
 		
+		WriteDebugLog(LOGINFO, "[STATUS: INITIATING ARQ DISCONNECT]");
 		QueueCommandToHost("STATUS INITIATING ARQ DISCONNECT");
 
 		intFrameRepeatInterval = 2000;
@@ -2470,7 +2495,7 @@ void Break()
 
 	if (ProtocolState != IRS)
 	{
-		WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.Break] |BREAK command received in ProtocolState: %s :", ARDOPStates[ProtocolState]);
+		WriteDebugLog(LOGINFO, "[ARDOPprotocol.Break] |BREAK command received in ProtocolState: %s :", ARDOPStates[ProtocolState]);
 		return;
 	}
 	

--- a/ARDOPC/HostInterface.c
+++ b/ARDOPC/HostInterface.c
@@ -415,7 +415,7 @@ void ProcessCommandFromHost(char * strCMD)
 		{
 			i = atoi(ptrParams);
 
-			if (i >= LOGEMERGENCY  && i <= LOGDEBUG)
+			if (i >= LOGEMERGENCY  && i <= LOGDEBUGPLUS)
 			{
 				ConsoleLogLevel = i;
 				sprintf(cmdReply, "%s now %d", strCMD, ConsoleLogLevel);
@@ -860,7 +860,7 @@ void ProcessCommandFromHost(char * strCMD)
 		{
 			i = atoi(ptrParams);
 
-			if (i >= LOGEMERGENCY  && i <= LOGDEBUG)
+			if (i >= LOGEMERGENCY  && i <= LOGDEBUGPLUS)
 			{
 				FileLogLevel = i;
 				sprintf(cmdReply, "%s now %d", strCMD, FileLogLevel);

--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -138,7 +138,7 @@ void Mod4FSKDataAndPlay(int Type, unsigned char * bytEncodedBytes, int Len, int 
 	if (strcmp(strMod, "4FSK") != 0)
 		return;
 
-	WriteDebugLog(LOGDEBUG, "Sending Frame Type %s", strType);
+	WriteDebugLog(LOGINFO, "Sending Frame Type %s", strType);
 	DrawTXFrame(strType);
 
 	if (Type == PktFrameHeader)
@@ -389,7 +389,7 @@ void Mod8FSKDataAndPlay(int Type, unsigned char * bytEncodedBytes, int Len, int 
 	if (strcmp(strMod, "8FSK") != 0)
 		return;
 
-	WriteDebugLog(LOGDEBUG, "Sending Frame Type %s", strType);
+	WriteDebugLog(LOGINFO, "Sending Frame Type %s", strType);
 	DrawTXFrame(strType);
 
 	initFilter(200,1500);
@@ -465,7 +465,7 @@ void Mod16FSKDataAndPlay(int Type, unsigned char * bytEncodedBytes, int Len, int
 	if (strcmp(strMod, "16FSK") != 0)
 		return;
 
-	WriteDebugLog(LOGDEBUG, "Sending Frame Type %s", strType);
+	WriteDebugLog(LOGINFO, "Sending Frame Type %s", strType);
 	DrawTXFrame(strType);
 
 	initFilter(500,1500);
@@ -534,7 +534,7 @@ void Mod4FSK600BdDataAndPlay(int Type, unsigned char * bytEncodedBytes, int Len,
 	if (strcmp(strMod, "4FSK") != 0)
 		return;
 
-	WriteDebugLog(LOGDEBUG, "Sending Frame Type %s", strType);
+	WriteDebugLog(LOGINFO, "Sending Frame Type %s", strType);
 	DrawTXFrame(strType);
 
 	initFilter(2000,1500);
@@ -686,7 +686,7 @@ void ModPSKDataAndPlay(int Type, unsigned char * bytEncodedBytes, int Len, int i
 		goto PktLoopBack;
 	}
 	
-	WriteDebugLog(LOGDEBUG, "Sending Frame Type %s", strType);
+	WriteDebugLog(LOGINFO, "Sending Frame Type %s", strType);
 	DrawTXFrame(strType);
 
 /*	// DOnt use PSK Header at the moment

--- a/ARDOPC/RXO.c
+++ b/ARDOPC/RXO.c
@@ -5,6 +5,9 @@
 extern UCHAR bytSessionID;
 extern UCHAR bytFrameData1[760];
 
+// Use of RXO is assumed to indicate that the user is interested in observing all received traffic.
+// So LOGINFO, rather than a higher log level such as LOGDEBUG, is used for most positive results.
+
 // Function to compute the "distance" from a specific bytFrame Xored by bytID using 1 symbol parity 
 // The tones representing the Frame Type include two parity symbols which should be identical, and
 // should match ComputeTypeParity(bytFrameType).  For RXO mode, the SessionID is unknown/unreliable,
@@ -95,7 +98,7 @@ BOOL RxoDecodeSessionID(UCHAR bytFrameType, int * intToneMags, float dblMaxDista
 				bytID, dblDistance, dblMaxDistance, bytSessionID);		
 	return TRUE;
 	}
-	WriteDebugLog(LOGDEBUG, "[RXO DecodeSessionID OK  ] Decoded ID=H%02X Dist=%.2f (%.2f Max). (Prior ID=H%02X)", 
+	WriteDebugLog(LOGINFO, "[RXO DecodeSessionID OK  ] Decoded ID=H%02X Dist=%.2f (%.2f Max). (Prior ID=H%02X)", 
 			bytID, dblDistance, dblMaxDistance, bytSessionID);	
 	bytSessionID = bytID;
 	return TRUE;
@@ -123,7 +126,7 @@ int RxoMinimalDistanceFrameType(int * intToneMags)
 	if (dblMinDistance < 0.3)
 	{
 		// Decode of Frame Type is Good independent of bytSessionID
-		WriteDebugLog(LOGDEBUG, "[Frame Type Decode OK  ] H%02X:%s", bytIatMinDistance, Name(bytIatMinDistance));
+		WriteDebugLog(LOGINFO, "[Frame Type Decode OK  ] H%02X:%s", bytIatMinDistance, Name(bytIatMinDistance));
 
 		// Only update bytSessionID if the decode distance is nearly as good as the 
 		// decode distance for the Frame Type.  Recall that the two parity tones and 
@@ -156,26 +159,26 @@ void ProcessRXOFrame(UCHAR bytFrameType, int frameLen, UCHAR * bytData, BOOL bln
 		if (bytFrameType >= 0x31 && bytFrameType <= 0x38)
 		{
 			// Is there a reason why frameLen is not defined for ConReq?
-			WriteDebugLog(LOGDEBUG, "    [RXO %02X] ConReq data is callerID targetID", bytSessionID);
+			WriteDebugLog(LOGINFO, "    [RXO %02X] ConReq data is callerID targetID", bytSessionID);
 			frameLen = strlen((char*) bytData);
 		}
 		else if (bytFrameType >= 0x39 && bytFrameType <= 0x3C)
 		{
-			WriteDebugLog(LOGDEBUG, "    [RXO %02X] ConAck data is the length (in tens of ms) of the received leader repeated 3 times: %d %d %d",
+			WriteDebugLog(LOGINFO, "    [RXO %02X] ConAck data is the length (in tens of ms) of the received leader repeated 3 times: %d %d %d",
 				bytSessionID, bytFrameData1[0], bytFrameData1[1], bytFrameData1[2]);
 		}
 		else if (bytFrameType >= 0xE0)
 		{
-			WriteDebugLog(LOGDEBUG, "    [RXO %02X] DataAck FrameType (0x%02X) indicates decode quality (%d/100). 60+ typically required for decoding.",
+			WriteDebugLog(LOGINFO, "    [RXO %02X] DataAck FrameType (0x%02X) indicates decode quality (%d/100). 60+ typically required for decoding.",
 				bytSessionID, bytFrameType, 38 + (2 * (bytFrameType & 0x1F)));
 		}
 		else if (bytFrameType <= 0x1F)
 		{
-			WriteDebugLog(LOGDEBUG, "    [RXO %02X] DataNak FrameType (0x%02X) indicates decode quality (%d/100). 60+ typically required for decoding.",
+			WriteDebugLog(LOGINFO, "    [RXO %02X] DataNak FrameType (0x%02X) indicates decode quality (%d/100). 60+ typically required for decoding.",
 				bytSessionID, bytFrameType, 38 + (2 * (bytFrameType & 0x1F)));
 		}
 
-		WriteDebugLog(LOGDEBUG, "    [RXO %02X] %s frame received OK.  frameLen = %d", 
+		WriteDebugLog(LOGINFO, "    [RXO %02X] %s frame received OK.  frameLen = %d", 
 				bytSessionID, Name(bytFrameType), frameLen);
 		bytData[frameLen] = 0;
 		if (frameLen > 0)
@@ -187,7 +190,7 @@ void ProcessRXOFrame(UCHAR bytFrameType, int frameLen, UCHAR * bytData, BOOL bln
 				sprintf(strMsg + intMsgLen, "%02X ", bytData[i]);
 				intMsgLen += 3;
 			}
-			WriteDebugLog(LOGDEBUG, "%s", strMsg);
+			WriteDebugLog(LOGINFO, "%s", strMsg);
 			notUtf8 = utf8_check(bytData);
 			if (notUtf8 == NULL)
 			{
@@ -196,10 +199,10 @@ void ProcessRXOFrame(UCHAR bytFrameType, int frameLen, UCHAR * bytData, BOOL bln
 					if (bytData[i] == 0x0D && bytData[i + 1] != 0x0A)
 						bytData[i] = 0x0A;
 				}
-				WriteDebugLog(LOGDEBUG, "    [RXO %02X] %d bytes of data as UTF-8 text:\n%s", bytSessionID, frameLen, bytData);
+				WriteDebugLog(LOGINFO, "    [RXO %02X] %d bytes of data as UTF-8 text:\n%s", bytSessionID, frameLen, bytData);
 			}
 			else
-				WriteDebugLog(LOGDEBUG, "    [RXO %02X] Data does not appear to be valid UTF-8 text.", bytSessionID);			
+				WriteDebugLog(LOGINFO, "    [RXO %02X] Data does not appear to be valid UTF-8 text.", bytSessionID);			
 		}
 		sprintf(strMsg, "STATUS [RXO %02X] %s frame received OK.", bytSessionID, Name(bytFrameType));
 		SendCommandToHost(strMsg);

--- a/ARDOPC/SCSHostInterface.c
+++ b/ARDOPC/SCSHostInterface.c
@@ -1141,7 +1141,7 @@ VOID ProcessSCSTextCommand(char * Command, int Len)
 		PutString("\r\nOK");
 		PTCMode = FALSE;
 		blnListen = TRUE;
-		ConsoleLogLevel = 6;
+		ConsoleLogLevel = LOGINFO;
 		WriteDebugLog(LOGINFO, "ARDOP Native Mode");
 	}
 

--- a/ARDOPC/SoundInput.c
+++ b/ARDOPC/SoundInput.c
@@ -1097,13 +1097,13 @@ void ProcessNewSamples(short * Samples, int nSamples)
 				
 					txSleep(250);
 
-					WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessNewSamples] ProtocolState=IRStoISS, substate = %s ACK received. Cease BREAKS, NewProtocolState=ISS, substate ISSData", ARQSubStates[ARQState]);
+					WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessNewSamples] ProtocolState=IRStoISS, substate = %s ACK received. Cease BREAKS, NewProtocolState=ISS, substate ISSData", ARQSubStates[ARQState]);
 					blnEnbARQRpt = FALSE;	// stop the BREAK repeats
 					intLastARQDataFrameToHost = -1; // initialize to illegal value to capture first new ISS frame and pass to host
 
 					if (bytCurrentFrameType == 0) //  hasn't been initialized yet
 					{
-						WriteDebugLog(LOGDEBUG, "[ARDOPprotocol.ProcessNewSamples, ProtocolState=IRStoISS, Initializing GetNextFrameData");
+						WriteDebugLog(LOGINFO, "[ARDOPprotocol.ProcessNewSamples, ProtocolState=IRStoISS, Initializing GetNextFrameData");
 		   				GetNextFrameData(&intShiftUpDn, 0, "", TRUE); // just sets the initial data, frame type, and sets intShiftUpDn= 0
 					}
 
@@ -1120,7 +1120,7 @@ void ProcessNewSamples(short * Samples, int nSamples)
 				ClearAllMixedSamples();
 				State = SearchingForLeader;
 				blnFrameDecodedOK = TRUE;
-				WriteDebugLog(LOGDEBUG, "[DecodeFrame] Frame: %s ", Name(intFrameType));
+				WriteDebugLog(LOGINFO, "[DecodeFrame] Frame: %s ", Name(intFrameType));
 
 				DecodeCompleteTime = Now;
 
@@ -3574,7 +3574,7 @@ BOOL Decode4FSKID(UCHAR bytFrameType, char * strCallID, char * strGridSquare)
 	unsigned char * p = bytFrameData1;
 
 
-	Debugprintf("%02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x  %02x %02x %02x %02x ",
+	WriteDebugLog(LOGDEBUG, "%02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x %02x  %02x %02x %02x %02x ",
 		p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]);
 
 
@@ -4143,7 +4143,7 @@ BOOL DecodeFrame(int xxx, UCHAR * bytData)
 				intNumCar = pktNumCar;
 				PSKInitDone = 0;
 
-				WriteDebugLog(6, "Pkt Frame Header Type %s Len %d", strMod, Len);
+				WriteDebugLog(LOGINFO, "Pkt Frame Header Type %s Len %d", strMod, Len);
 				strlop(strMod, '/');
 				blnDecodeOK = TRUE;
 

--- a/ARDOPC/TCPHostInterface.c
+++ b/ARDOPC/TCPHostInterface.c
@@ -235,7 +235,7 @@ void TCPAddTagToDataAndSendToHost(UCHAR * bytData, char * strTag, int Len)
 	if (blnInitializing)
 		return;
 
-	if (CommandTrace) WriteDebugLog(LOGINFO, "[AddTagToDataAndSendToHost] bytes=%d Tag %s", Len, strTag);
+	if (CommandTrace) WriteDebugLog(LOGDEBUG, "[AddTagToDataAndSendToHost] bytes=%d Tag %s", Len, strTag);
 
 	//	Have to save copy for possible retry (and possibly until previous 
 	//	command is acked
@@ -292,9 +292,9 @@ void ProcessReceivedControl()
 
 	//	Commands start with c: and end with CR.
 	//	Data starts with d: and has a length field
-	//	“d:ARQ|FEC|ERR|, 2 byte count (Hex 0001 – FFFF), binary data, +2 Byte CRC”
+	//	"d:ARQ|FEC|ERR|, 2 byte count (Hex 0001 - FFFF), binary data, +2 Byte CRC"
 
-	//	As far as I can see, shortest frame is “c:RDY<Cr> + 2 byte CRC” = 8 bytes
+	//	As far as I can see, shortest frame is "c:RDY<Cr> + 2 byte CRC" = 8 bytes
 
 	//	I don't think it likely we will get packets this long, but be aware...
 
@@ -400,9 +400,9 @@ void ProcessReceivedData()
 
 	//	Commands start with c: and end with CR.
 	//	Data starts with d: and has a length field
-	//	“d:ARQ|FEC|ERR|, 2 byte count (Hex 0001 – FFFF), binary data, +2 Byte CRC”
+	//	"d:ARQ|FEC|ERR|, 2 byte count (Hex 0001 - FFFF), binary data, +2 Byte CRC"
 
-	//	As far as I can see, shortest frame is “c:RDY<Cr> + 2 byte CRC” = 8 bytes
+	//	As far as I can see, shortest frame is "c:RDY<Cr> + 2 byte CRC" = 8 bytes
 
 	//	I don't think it likely we will get packets this long, but be aware...
 

--- a/ARDOPCommonCode/ALSASound.c
+++ b/ARDOPCommonCode/ALSASound.c
@@ -481,6 +481,8 @@ void main(int argc, char * argv[])
 	setlinebuf(stdout);				// So we can redirect output to file and tail
 
 	Debugprintf("%s Version %s", ProductName, ProductVersion);
+	Debugprintf("ConsoleLogLevel = %d (%s)", ConsoleLogLevel, strLogLevels[ConsoleLogLevel]);
+	Debugprintf("FileLogLevel = %d (%s)", FileLogLevel, strLogLevels[FileLogLevel]);
 
 	if (DecodeWav[0])
 	{
@@ -1654,7 +1656,7 @@ void PollReceivedSamples()
 				sprintf(HostCmd, "INPUTPEAKS %d %d", min, max);
 				SendCommandToHostQuiet(HostCmd);
 
-				WriteDebugLog(LOGDEBUG, "Input peaks = %d, %d", min, max);
+				WriteDebugLog(LOGINFO, "Input peaks = %d, %d", min, max);
 			}
 			min = max = 0;							// Every 2 secs
 		}
@@ -1814,7 +1816,7 @@ void SoundFlush()
 
 	txlenMs = SampleNo / 12 + 20;		// 12000 samples per sec. 20 mS TXTAIL
 
-	Debugprintf("Tx Time %d Time till end = %d", txlenMs, (pttOnTime + txlenMs) - Now);
+	WriteDebugLog(LOGDEBUG, "Tx Time %d Time till end = %d", txlenMs, (pttOnTime + txlenMs) - Now);
 
 	while (Now < (pttOnTime + txlenMs))
 	{

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -49,6 +49,19 @@ const char ProductVersion[] = "2.0.3.2-pflarue-3";
 #include "wav.h"
 #include "getopt.h"
 
+const char strLogLevels[9][13] =
+{
+	"LOGEMERGENCY", 
+	"LOGALERT",
+	"LOGCRIT",
+	"LOGERROR",
+	"LOGWARNING",
+	"LOGNOTICE",
+	"LOGINFO",
+	"LOGDEBUG",
+	"LOGDEBUGPLUS"
+};
+
 extern int gotGPIO;
 extern int useGPIO;
 
@@ -155,6 +168,8 @@ extern char LogDir[256];
 static struct option long_options[] =
 {
 	{"logdir",  required_argument, 0 , 'l'},
+	{"verboselog",  required_argument, 0 , 'v'},
+	{"verboseconsole",  required_argument, 0 , 'V'},
 	{"ptt",  required_argument, 0 , 'p'},
 	{"cat",  required_argument, 0 , 'c'},
 	{"keystring",  required_argument, 0 , 'k'},
@@ -184,6 +199,8 @@ char HelpScreen[] =
 	"\n"
 	"Optional Paramters\n"
 	"-l path or --logdir path             Path for log files\n"
+	"-v path or --verboselog val          Increase (decr for val<0) file log level from default.\n"
+	"-V path or --verboseconsole val      Increase (decr for val<0) console log level from default.\n"
 	"-c device or --cat device            Device to use for CAT Control\n"
 	"-p device or --ptt device            Device to use for PTT control using RTS\n"
 #ifdef LINBPQ
@@ -222,7 +239,7 @@ void processargs(int argc, char * argv[])
 	{		
 		int option_index = 0;
 
-		c = getopt_long(argc, argv, "l:c:p:g::k:u:e:hLRytrzwTW:ns", long_options, &option_index);
+		c = getopt_long(argc, argv, "l:v:V:c:p:g::k:u:e:hLRytrzwTW:ns", long_options, &option_index);
 
 		// Check for end of operation or error
 		if (c == -1)
@@ -241,6 +258,21 @@ void processargs(int argc, char * argv[])
 			strcpy(LogDir, optarg);
 			break;
 
+		case 'v':
+			FileLogLevel += atoi(optarg);
+			if (FileLogLevel > LOGDEBUGPLUS)
+				FileLogLevel = LOGDEBUGPLUS;
+			else if (FileLogLevel < LOGEMERGENCY)
+				FileLogLevel = LOGEMERGENCY;
+			break;
+
+		case 'V':
+			ConsoleLogLevel += atoi(optarg);
+			if (ConsoleLogLevel > LOGDEBUGPLUS)
+				ConsoleLogLevel = LOGDEBUGPLUS;
+			else if (ConsoleLogLevel < LOGEMERGENCY)
+				ConsoleLogLevel = LOGEMERGENCY;
+			break;
 			
 		case 'g':
 			if (optarg)

--- a/ARDOPCommonCode/Waveout.c
+++ b/ARDOPCommonCode/Waveout.c
@@ -375,6 +375,8 @@ void main(int argc, char * argv[])
 	}
 
 	WriteDebugLog(LOGALERT, "%s Version %s", ProductName, ProductVersion);
+	WriteDebugLog(LOGALERT, "ConsoleLogLevel = %d (%s)", ConsoleLogLevel, strLogLevels[ConsoleLogLevel]);
+	WriteDebugLog(LOGALERT, "FileLogLevel = %d (%s)", FileLogLevel, strLogLevels[FileLogLevel]);
 
 	if (DecodeWav[0])
 	{
@@ -739,7 +741,7 @@ void PollReceivedSamples()
 				lastlevelreport = Now;
 
 				sprintf(HostCmd, "INPUTPEAKS %d %d", min, max);
-				WriteDebugLog(LOGDEBUG, "Input peaks = %d, %d", min, max);
+				WriteDebugLog(LOGINFO, "Input peaks = %d, %d", min, max);
 				SendCommandToHostQuiet(HostCmd);
 
 			}

--- a/ARDOPCommonCode/ardopcommon.h
+++ b/ARDOPCommonCode/ardopcommon.h
@@ -46,6 +46,8 @@ unsigned int getTicks();
 #define LOGDEBUG 7
 #define LOGDEBUGPLUS 8
 
+extern const char strLogLevels[9][13];
+
 #include <time.h>
 
 #include <stdio.h>
@@ -388,8 +390,8 @@ extern BOOL AccumulateStats;
 extern BOOL Use600Modes;
 extern BOOL FSKOnly;
 extern BOOL fastStart;
-extern BOOL ConsoleLogLevel;
-extern BOOL FileLogLevel;
+extern int ConsoleLogLevel;
+extern int FileLogLevel;
 extern BOOL EnablePingAck;
 
 extern int dttLastPINGSent;


### PR DESCRIPTION
The ConsoleLogLevel and FileLogLevel variables in ardopc control how verbose the console and the debug log file are.  ConsoleLogLevel can be changed with the host CONSOLELOG command.  FileLogLevel can be changed with the LOGLEVEL command.  These features are not new.

The new -v or --verboselog command line arguments can be used to set the initial value of FileLogLevel with respect to the default of 6 (LOGINFO).  The new -V or --verboseconsole command line arguments can be used to set the initial value of ConsoleLogLevel with respect to the default of 7 (LOGDEBUG).   Thus, arguments of -V -2 -v 1 would set ConsoleLogLevel to a less verbose 4 (LOGWARNING) and FileLogLevel to a more verbose 8 (LOGDEBUGPLUS).

The default console and file log levels were adjusted from their previous values.  Many individual log commands were modified, and some new ones were added.  These changes are intended to write less information to the console, while adding some key information that was not previously written, or which was hard to find because it was mixed in with too much detail that this author believes is better put only into the log file.  The new command line arguments make it easier for users to choose the amount of information that they want to see.  A normal user may want to see very little log information, while someone trying to debug a problem may want more detail.