### PR TITLE
Exit ardop if InitSound() fails and not from bad tx-timing-fix.

### DIFF
--- a/ARDOPC/ARDOPC.c
+++ b/ARDOPC/ARDOPC.c
@@ -779,7 +779,11 @@ void ardopmain()
 	blnTimeoutTriggered = FALSE;
 	SetARDOPProtocolState(DISC);
 
-	InitSound();
+	if (!InitSound())
+	{
+		WriteDebugLog(LOGCRIT, "Error in InitSound().  Stopping ardop.");
+		return;
+	}
 
 	if (SerialMode)
 		SerialHostInit();

--- a/ARDOPC/ARDOPC.h
+++ b/ARDOPC/ARDOPC.h
@@ -276,7 +276,7 @@ void GetSemaphore();
 void FreeSemaphore();
 const char * Name(UCHAR bytID);
 const char * shortName(UCHAR bytID);
-void InitSound();
+int InitSound();
 void initFilter(int Width, int centerFreq);
 void FourierTransform(int NumSamples, short * RealIn, float * RealOut, float * ImagOut, int InverseTransform);
 VOID ClosePacketSessions();

--- a/ARDOPC/NucleoSound.c
+++ b/ARDOPC/NucleoSound.c
@@ -133,10 +133,11 @@ int inIndex = 0;				// DMA Buffer being used 0 or 1
 
 BOOL DMARunning = FALSE;		// Used to start DMA on first write
 
-void InitSound()
+int InitSound()
 {
 	Config_ADC_DMA();
 	Start_ADC_DMA();
+	return TRUE;
 }
 
 unsigned short * SendtoCard(unsigned short buf, int n)

--- a/ARDOPCommonCode/Waveout.c
+++ b/ARDOPCommonCode/Waveout.c
@@ -120,7 +120,7 @@ WAVEINCAPS pwic;
 
 unsigned int RTC = 0;
 
-void InitSound(BOOL Quiet);
+int InitSound(BOOL Quiet);
 void HostPoll();
 void TCPHostPoll();
 void SerialHostPoll();
@@ -501,7 +501,11 @@ void main(int argc, char * argv[])
 
 	if (TwoToneAndExit)
 	{
-		InitSound(TRUE);
+		if (!InitSound(TRUE)
+		{
+			WriteDebugLog(LOGCRIT, "Error in InitSound().  Stopping ardop.");
+			return;
+		}
 		WriteDebugLog(LOGINFO, "Sending a 5 second 2-tone signal. Then exiting ardop.");
 		Send5SecTwoTone();
 		return;
@@ -632,7 +636,7 @@ void GetSoundDevices()
 }
 
 
-void InitSound(BOOL Report)
+int InitSound(BOOL Report)
 {
 	int i, ret;
 
@@ -703,6 +707,7 @@ void InitSound(BOOL Report)
 	}
 
 	ret = waveInStart(hWaveIn);
+	return true;
 }
 
 int min = 0, max = 0, lastlevelGUI = 0, lastlevelreport = 0;

--- a/ARDOPCommonCode/ardopcommon.h
+++ b/ARDOPCommonCode/ardopcommon.h
@@ -260,7 +260,7 @@ void GetSemaphore();
 void FreeSemaphore();
 const char * Name(UCHAR bytID);
 const char * shortName(UCHAR bytID);
-void InitSound();
+int InitSound();
 void initFilter(int Width, int centerFreq);
 void FourierTransform(int NumSamples, short * RealIn, float * RealOut, float * ImagOut, int InverseTransform);
 VOID ClosePacketSessions();


### PR DESCRIPTION
Previously, if InitSound() failed, ardop continued to run with the user perhaps not immediately noticing the problem.  This commit causes ardop to write an error to the console and log, and then exit if InitSound() fails.

This commit also adjusts what happens if an attempt to fix an ALSA configuration error fails.  Previously, this would have caused InitSound() to fail.  Now, instead, it writes an error to the console and log, and then reverts to the default ALSA configuration.  The logic behind this is that while the ALSA configuration error may make it more difficult for other stations to decode the transmissions, it may still be usable.  Even marginally usable is better than not usable at all.