### PR TITLE
For mingw64 (ardopc)

### DIFF
--- a/ARDOPC/ARDOPC.c
+++ b/ARDOPC/ARDOPC.c
@@ -17,7 +17,6 @@ const char ProductName[] = "ardopc";
 
 #ifdef WIN32
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #include <windows.h>
 #include <mmsystem.h>

--- a/ARDOPC/ARDOPC.h
+++ b/ARDOPC/ARDOPC.h
@@ -29,7 +29,6 @@ extern const char ProductVersion[];
 
 #define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #ifndef WIN32
 #define max(x, y) ((x) > (y) ? (x) : (y))

--- a/ARDOPC/ARQ.c
+++ b/ARDOPC/ARQ.c
@@ -4,7 +4,6 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #include <windows.h>
 #include <mmsystem.h>

--- a/ARDOPC/BusyDetect.c
+++ b/ARDOPC/BusyDetect.c
@@ -2,7 +2,6 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #include <windows.h>
 #endif

--- a/ARDOPC/KISSModule.c
+++ b/ARDOPC/KISSModule.c
@@ -16,7 +16,6 @@
 
 #ifdef WIN32
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #include <windows.h>
 #include <winioctl.h>

--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -2,7 +2,6 @@
 
 #ifdef WIN32
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 #include <windows.h>
 #endif
 

--- a/ARDOPC/SoundInput.c
+++ b/ARDOPC/SoundInput.c
@@ -2,7 +2,6 @@
 
 #ifdef WIN32
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 #include <windows.h>
 #endif
 

--- a/ARDOPC/TCPHostInterface.c
+++ b/ARDOPC/TCPHostInterface.c
@@ -3,7 +3,6 @@
 
 #ifdef WIN32
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 #include <windows.h>
 #pragma comment(lib, "WS2_32.Lib")
 

--- a/ARDOPC/WinSerial.c
+++ b/ARDOPC/WinSerial.c
@@ -4,7 +4,6 @@
 
 #ifdef WIN32
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #include <windows.h>
 #include <winioctl.h>

--- a/ARDOPC/afskModule.c
+++ b/ARDOPC/afskModule.c
@@ -14,7 +14,6 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #include <windows.h>
 #include <winioctl.h>

--- a/ARDOPC/pktARDOP.c
+++ b/ARDOPC/pktARDOP.c
@@ -17,7 +17,6 @@
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #include <windows.h>
 #include <winioctl.h>

--- a/ARDOPC/pktSession.c
+++ b/ARDOPC/pktSession.c
@@ -371,6 +371,10 @@ unsigned int ReleaseBuffer(VOID *pBUFF)
 	return 0;
 }
 
+/*
+// win64 Compiler warning in this function.
+// Since it doesn't appear to be used anywhere, comment it out
+// rather than debug it.
 int C_Q_ADD(VOID *PQ, VOID *PBUFF)
 {
 	unsigned int * Q;
@@ -400,6 +404,7 @@ int C_Q_ADD(VOID *PQ, VOID *PBUFF)
 
 	return(0);
 }
+*/
 
 BOOL ConvToAX25(char * callsign, unsigned char * ax25call)
 {

--- a/ARDOPC/pktSession.c
+++ b/ARDOPC/pktSession.c
@@ -21,7 +21,6 @@ along with LinBPQ/BPQ32.  If not, see http://www.gnu.org/licenses
 
 #ifdef WIN32
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #include <windows.h>
 #include <winioctl.h>

--- a/ARDOPCommonCode/ARDOPCommon.c
+++ b/ARDOPCommonCode/ARDOPCommon.c
@@ -23,7 +23,6 @@ const char ProductVersion[] = "2.0.3.2-pflarue-3";
 
 #ifdef WIN32
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #include <windows.h>
 #include <mmsystem.h>

--- a/ARDOPCommonCode/Waveout.c
+++ b/ARDOPCommonCode/Waveout.c
@@ -1200,7 +1200,7 @@ HANDLE OpenCOMPort(VOID * pPort, int speed, BOOL SetDTR, BOOL SetRTS, BOOL Quiet
 
 	// if Port Name starts COM, convert to \\.\COM or ports above 10 wont work
 
-	if ((unsigned int)pPort < 256)			// just a com port number
+	if (atoi(pPort) != 0)			// just a com port number
 		sprintf( szPort, "\\\\.\\COM%d", pPort);
 
 	else if (_memicmp(pPort, "COM", 3) == 0)
@@ -1225,8 +1225,8 @@ HANDLE OpenCOMPort(VOID * pPort, int speed, BOOL SetDTR, BOOL SetRTS, BOOL Quiet
 	{
 		if (Quiet == 0)
 		{
-			if (pPort < (VOID *)256)
-				sprintf(buf," COM%d could not be opened \r\n ", (unsigned int)pPort);
+			if (atoi(pPort) != 0)
+				sprintf(buf," COM%d could not be opened \r\n ", atoi(pPort));
 			else
 				sprintf(buf," %s could not be opened \r\n ", pPort);
 
@@ -1299,8 +1299,8 @@ HANDLE OpenCOMPort(VOID * pPort, int speed, BOOL SetDTR, BOOL SetRTS, BOOL Quiet
 	}
 	else
 	{
-		if ((unsigned int)pPort < 256)
-			sprintf(buf,"COM%d Setup Failed %d ", pPort, GetLastError());
+		if (atoi(pPort) != 0)
+			sprintf(buf,"COM%d Setup Failed %d ", atoi(pPort), GetLastError());
 		else
 			sprintf(buf,"%s Setup Failed %d ", pPort, GetLastError());
 

--- a/ARDOPCommonCode/Waveout.c
+++ b/ARDOPCommonCode/Waveout.c
@@ -10,7 +10,6 @@
 //	This is the Windows Version
 
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #include <windows.h>
 #include <mmsystem.h>

--- a/ARDOPCommonCode/ardopcommon.h
+++ b/ARDOPCommonCode/ardopcommon.h
@@ -21,7 +21,6 @@ extern const char ProductVersion[];
 
 #define WIN32_LEAN_AND_MEAN		// Exclude rarely-used stuff from Windows headers
 #define _CRT_SECURE_NO_DEPRECATE
-#define _USE_32BIT_TIME_T
 
 #ifndef WIN32
 #define max(x, y) ((x) > (y) ? (x) : (y))


### PR DESCRIPTION
A previous branch allowed ardopc to be compiled for Windows 32-bit.  This branch allows the existing Makefile_mingw32 to also cleanly compile ardopc on a Windows PC using winlibs Intel/AMD 64-bit (https://winlibs.com/). It may also work for other Windows based c compiler systems, but these are the only ones that have been tested at this time.