### PR TITLE
make clean will clean the dependancies and output map

### DIFF
--- a/ARDOPC/Makefile
+++ b/ARDOPC/Makefile
@@ -21,5 +21,5 @@ ardopcf: $(OBJS)
 -include *.d
 
 clean :
-	rm ardopcf $(OBJS)
+	rm ardopcf $(OBJS) $(OBJS:.o=.d) output.map
 

--- a/ARDOPCommonCode/ALSASound.c
+++ b/ARDOPCommonCode/ALSASound.c
@@ -1305,7 +1305,7 @@ int OpenSoundPlayback(char * PlaybackDevice, int m_sampleRate, int channels, cha
 		else
 		{
 			// This branch is untested since a case where the configuration can't be fixed has not been found.
-			WriteDebugLog(LOGERROR, "After failed attempt to fix: intPeriodTime=%d, intRate=$d, periodSize=%d.",
+			WriteDebugLog(LOGERROR, "After failed attempt to fix: intPeriodTime=%d, intRate=%d, periodSize=%d.",
 				intPeriodTime, intRate, periodSize);
 			WriteDebugLog(LOGERROR, "intPeriodTime * intRate == periodSize * 1000000?  %d == %d?",
 				intPeriodTime * intRate, periodSize * 1000000);


### PR DESCRIPTION
When you compile, make will generate a bunch of *.d dependency files and an output.map which are never cleaned up after a make clean.