### PR TITLE
Input Peaks warnings for approaching threshold, and still available to constantly send to host and console if in debug mode.

### DIFF
--- a/ARDOPCommonCode/ALSASound.c
+++ b/ARDOPCommonCode/ALSASound.c
@@ -1841,13 +1841,20 @@ void PollReceivedSamples()
 
 			if ((Now - lastlevelreport) > 10000)	// 10 Secs
 			{
-				char HostCmd[64];
-				lastlevelreport = Now;
+				if (max >= 32000 || ConsoleLogLevel >= LOGDEBUG)
+				{
+					char HostCmd[64];
+					lastlevelreport = Now;
 
-				sprintf(HostCmd, "INPUTPEAKS %d %d", min, max);
-				SendCommandToHostQuiet(HostCmd);
-
-				WriteDebugLog(LOGINFO, "Input peaks = %d, %d", min, max);
+					sprintf(HostCmd, "INPUTPEAKS %d %d", min, max);
+					SendCommandToHostQuiet(HostCmd);
+					WriteDebugLog(LOGINFO, "Input peaks = %d, %d", min, max);
+					// A user NOT in debug mode will see this message if they are clipping
+					if (ConsoleLogLevel <= LOGINFO)
+					{
+						WriteDebugLog(LOGINFO, "Your input signal is probably clipping. Turn down your RX volume control until this warning goes away.");
+					}
+				}
 			}
 			min = max = 0;							// Every 2 secs
 		}

--- a/ARDOPCommonCode/Waveout.c
+++ b/ARDOPCommonCode/Waveout.c
@@ -751,12 +751,19 @@ void PollReceivedSamples()
 
 			if ((Now - lastlevelreport) > 10000)	// 10 Secs
 			{
-				char HostCmd[64];
-				lastlevelreport = Now;
-
-				sprintf(HostCmd, "INPUTPEAKS %d %d", min, max);
-				WriteDebugLog(LOGINFO, "Input peaks = %d, %d", min, max);
-				SendCommandToHostQuiet(HostCmd);
+				if (max >= 32000 || ConsoleLogLevel >= LOGDEBUG)
+				{
+					char HostCmd[64];
+					lastlevelreport = Now;
+					sprintf(HostCmd, "INPUTPEAKS %d %d", min, max);
+					SendCommandToHostQuiet(HostCmd);
+					WriteDebugLog(LOGINFO, "Input peaks = %d, %d", min, max);
+					// A user NOT in debug mode will see this message if they are clipping
+					if (ConsoleLogLevel <= LOGINFO)
+					{
+						WriteDebugLog(LOGINFO, "Your input signal is probably clipping. Turn down your RX volume control until this warning goes away.");
+					}
+				}
 
 			}
 			min = max = 0;


### PR DESCRIPTION
INPUTPEAKS will now show a warning to the user if their input audio is close to clipping, or they are running this as LOGDEBUG or LOGDEBUGPLUS. Users NOT in debug mode will recieve a verbose warning telling them what INPUTPEAKS means.

The value of 32000 is 97% of the maximum, which I figured was a reasonable input level to warn the user to turn it down.