### PR TITLE
Disable CODEC host command.

### DIFF
--- a/ARDOPC/HostInterface.c
+++ b/ARDOPC/HostInterface.c
@@ -405,6 +405,10 @@ void ProcessCommandFromHost(char * strCMD)
 		goto cmddone;
 	}
 
+	// I'm not sure what CODEC is intended to do, but using it causes a
+	// segfault.  It doesn't seem to be required for normal use, so disable
+	// this command until it is better understood.  -LaRue May 2024
+	/*
 	if (strcmp(strCMD, "CODEC") == 0)
 	{
 		DoTrueFalseCmd(strCMD, ptrParams, &blnCodecStarted);
@@ -416,6 +420,7 @@ void ProcessCommandFromHost(char * strCMD)
 	
 		goto cmddone;
 	}
+	*/
 
 	if (strcmp(strCMD, "CONSOLELOG") == 0)
 	{


### PR DESCRIPTION
It is not clear what the CODEC host command was intended to do, or why.  It seems to close the soundcard interface, which causes ardopcf to crash.  I don't understand why this would be done via a host command.  So, for now, disable the CODEC host command in HostInterface.c.  If/when the intent of this command later becomes clearer, then a better fix might be implemented.