### PR TITLE
Fix 1 Carrier PSK frame TX audio frequency

### DIFF
--- a/ARDOPC/ARDOPC.c
+++ b/ARDOPC/ARDOPC.c
@@ -2616,7 +2616,7 @@ void generateBH() {
 			+ 0.14128 * cos(4 * M_PI * i / 1024) - 0.01168 * cos(6 * M_PI * i / 1024);
 		wS1 += 2 * bhWindow[i];
 	}
-	// wS1 should only include one of terms , 512
+	// wS1 should only include one of terms 0, 512
 	wS1 -= bhWindow[0] + bhWindow[512];
 }
 
@@ -2656,7 +2656,7 @@ void UpdateBusyDetector(short * bytNewSamples)
 	LastBusyCheck = Now;
 
 	// Apply a Blackman-Harris window before doing FFT
-	// The will decrease spectral leakage.  It also decreases the magnitude 
+	// This will decrease spectral leakage.  It also decreases the magnitude 
 	// of the FFT results by wS1/1024
 	if (wS1 == 0)
 		generateBH();

--- a/ARDOPC/ARQ.c
+++ b/ARDOPC/ARQ.c
@@ -2457,6 +2457,7 @@ int IRSNegotiateBW(int intConReqFrameType)
 			intSessionBW = 1000;
 			return ConAck1000;
 		}
+		break;
            
 	case B2000MAX:
 

--- a/ARDOPC/FFT.c
+++ b/ARDOPC/FFT.c
@@ -53,6 +53,8 @@
 */
 
 #include <math.h>
+#include <stdbool.h>
+#include <stdlib.h>
 
 #ifdef M_PI
 #undef M_PI
@@ -175,5 +177,79 @@ void FourierTransform(int NumSamples, float * RealIn, float * RealOut, float * I
 		}
 	}
 }
- 
 
+
+// Return the the fundamental frequency (in Hz) of a set of (float) data.
+// This is intended for diagnostic or debugging purposes, not to be called
+// repeatedly for real time signal processing.  So, it was not created to be
+// particularly fast or efficient.  To be more efficient, srclen would be
+// a fixed value so that the Blackman-Harris window coefficients could be
+// calculated only once.  A fixed fftlen would also avoid the need for
+// dynamic memory allocation.
+//
+// If srclen is greater than fftlen, only the first fftlen samples of src
+// will be considered,
+float peakFrequency(const float *src, int srclen, int fftlen) {
+	float *samples;
+	float *re;
+	float *im;
+	float mag;
+	float maxmag;
+	int i;
+	int maxindex;
+
+	samples = (float *) malloc(3 * fftlen * sizeof(float));
+	re = samples + fftlen;
+	im = re + fftlen;
+
+	if (srclen > fftlen)
+		srclen = fftlen;
+	if (srclen % 2 == 1)
+		srclen--;
+
+	for(i = 0; i < srclen; i++) {
+		// Apply a Blackman-Harris window before doing FFT
+		// This will decrease spectral leakage.  It also decreases the magnitude
+		// of the FFT results, but this is OK since the goal is only to find
+		// which bin is largest, without caring about scale.
+		samples[i] = src[i] * (
+			0.35875 - 0.48829 * cos(2 * M_PI * i / srclen)
+			+ 0.14128 * cos(4 * M_PI * i / srclen)
+			- 0.01168 * cos(6 * M_PI * i / srclen));
+	}
+	// zero pad to increase length to fftlen (which controls frequency resolution).
+	// Like the window, this makes magnitudes less meaningful, but that is OK for
+	// this application.
+	for (; i < fftlen; i++)
+		samples[i] = 0.0;
+	FourierTransform(fftlen, samples, re, im, false);
+	// Find Peak
+	// samples are assumed to have been sampled at 12000 samples per second.
+	// So re[i] and im[i] correspond to a frequency of i * 12000 / fftlen
+	// for 0 <= i < fftlen/2.  Thus, error is about +/- 12000 / fftlen;
+	maxmag = 0.0;
+	maxindex = 0;
+	for (i = 1; i < fftlen/ 2; i++)
+	{
+		mag = powf(re[i], 2) + powf(im[i], 2);  // magnitude squared
+		if (mag > maxmag) {
+			maxmag = mag;
+			maxindex = i;
+		}
+	}
+	free(samples);
+	return (maxindex * 12000.0 / fftlen);
+}
+
+// A wrapper for peakFrequency to take 16-bit signed short ints as input
+// rather than floats.
+float peakFrequencyShorts(const short *src, int srclen, int fftlen) {
+	float *samples;
+	float result;
+	samples = (float *) malloc(fftlen * sizeof(float));
+	for(int i = 0; i < srclen; i++)
+		samples[i] = (float) src[i];
+	result = peakFrequency(samples, srclen, fftlen);
+	free(samples);
+	return (result);
+}

--- a/ARDOPC/Modulate.c
+++ b/ARDOPC/Modulate.c
@@ -702,6 +702,7 @@ void ModPSKDataAndPlay(int Type, unsigned char * bytEncodedBytes, int Len, int i
 		intCarStartIndex = 4;
 //		dblCarScalingFactor = 1.0f; // Starting at 1500 Hz  (scaling factors determined emperically to minimize crest factor)  TODO:  needs verification
 		dblCarScalingFactor = 1.2f; // Starting at 1500 Hz  Selected to give < 13% clipped values yielding a PAPR = 1.6 Constellation Quality >98
+		break;
 	case 2:
 		intCarStartIndex = 3;
 //		dblCarScalingFactor = 0.53f;
@@ -1008,6 +1009,7 @@ PktLoopBack:		// Reenter here to send rest of variable length packet frame
 			intCarStartIndex = 4;
 //			dblCarScalingFactor = 1.0f; // Starting at 1500 Hz  (scaling factors determined emperically to minimize crest factor)  TODO:  needs verification
 			dblCarScalingFactor = 1.2f; // Starting at 1500 Hz  Selected to give < 13% clipped values yielding a PAPR = 1.6 Constellation Quality >98
+			break;
 		case 2:
 			intCarStartIndex = 3;
 //			dblCarScalingFactor = 0.53f;

--- a/ARDOPC/SoundInput.c
+++ b/ARDOPC/SoundInput.c
@@ -4129,6 +4129,7 @@ BOOL DecodeFrame(int xxx, UCHAR * bytData)
 				DrawRXFrame(1, Name(intFrameType));
 				wg_send_rxframet(0, 1, Name(intFrameType));
 			}
+			break;
 
 		case 0x7A:
 		case 0x7B:
@@ -4247,6 +4248,7 @@ BOOL DecodeFrame(int xxx, UCHAR * bytData)
 
 				return 0;
 		}
+		break;
 
 					
 		case PktFrameData:


### PR DESCRIPTION
Fix a bug that caused 1 Carrier PSK frames to transmit on the wrong audio frequency.  This made these frames much harder to correctly decode, and increased the bandwidth of these modes.  These are 3 of the 5 modes used for 200 bandwidth connections and 2 of the 6 used for 500 bandwidth connections.  Thus, when connecting to those Winlink stations that only accept 500 bandwidth connections, as many do, this may significantly improve performance under less than optimal band conditions.

A couple of additional fixes are included in this pull request, including one that avoids mistakenly accepting a ConReq2000F when ARQ bandwidth is set to 1000MAX.

For diagnostic purposes, a new function was created to identify the peak frequency in a set of audio samples.  This function was instrumental in identifying and fixing the audio frequency bug.