### PR TITLE
Allow ardopcf to be run without connecting to a soundcard

### DIFF
--- a/ARDOPCommonCode/ALSASound.c
+++ b/ARDOPCommonCode/ALSASound.c
@@ -93,7 +93,8 @@ extern int useHamLib;
 
 void Sleep(int mS)
 {
-	usleep(mS * 1000);
+	if (strcmp(PlaybackDevice, "NOSOUND") != 0)
+		usleep(mS * 1000);
 	return;
 }
 
@@ -455,7 +456,8 @@ void PlatformSleep(int mS)
 		WebguiPoll();
 	}
 
-	Sleep(mS);
+	if (strcmp(PlaybackDevice, "NOSOUND") != 0)
+		Sleep(mS);
 		
 	if (PKTLEDTimer && Now > PKTLEDTimer)
     {
@@ -778,7 +780,8 @@ void txSleep(int mS)
 		WebguiPoll();
 	}
 
-	Sleep(mS);
+	if (strcmp(PlaybackDevice, "NOSOUND") != 0)
+		Sleep(mS);
 
 	if (PKTLEDTimer && Now > PKTLEDTimer)
     {
@@ -1810,6 +1813,8 @@ short loopbuff[1200];		// Temp for testing - loop sent samples to decoder
 
 int InitSound(BOOL Quiet)
 {
+	if (strcmp(PlaybackDevice, "NOSOUND") == 0)
+		return (1);
 	GetInputDeviceCollection();
 	GetOutputDeviceCollection();
 	return OpenSoundCard(CaptureDevice, PlaybackDevice, 12000, 12000, NULL);
@@ -1821,6 +1826,9 @@ UCHAR CurrentLevel = 0;		// Peak from current samples
 
 void PollReceivedSamples()
 {
+	if (strcmp(PlaybackDevice, "NOSOUND") == 0)
+		return;
+
 	// Process any captured samples
 	// Ideally call at least every 100 mS, more than 200 will loose data
 
@@ -1882,6 +1890,9 @@ Turn down your RX input until this message stops repeating.");
 void StopCapture()
 {
 	Capturing = FALSE;
+
+	if (strcmp(PlaybackDevice, "NOSOUND") == 0)
+		return;
 
 #ifdef SHARECAPTURE
 
@@ -2025,8 +2036,6 @@ void SoundFlush()
 
 	SendtoCard(&buffer[Index][0], Number);
 
-	usleep(200000);
-
 	// Wait for tx to complete
 
 	// samples sent is is in SampleNo, time started in mS is in pttOnTime.
@@ -2036,10 +2045,11 @@ void SoundFlush()
 
 	WriteDebugLog(LOGDEBUG, "Tx Time %d Time till end = %d", txlenMs, (pttOnTime + txlenMs) - Now);
 
-	while (Now < (pttOnTime + txlenMs))
-	{
-		usleep(2000);
-	}
+	if (strcmp(PlaybackDevice, "NOSOUND") != 0)
+		while (Now < (pttOnTime + txlenMs))
+		{
+			usleep(2000);
+		}
 
 /*
 
@@ -2078,10 +2088,12 @@ void SoundFlush()
 	// waiting for MainPoll
 
 #ifdef SHARECAPTURE
-	if (playhandle)
-	{
-		snd_pcm_close(playhandle);
-		playhandle = NULL;
+	if (strcmp(PlaybackDevice, "NOSOUND") != 0) {
+		if (playhandle)
+		{
+			snd_pcm_close(playhandle);
+			playhandle = NULL;
+		}
 	}
 #endif
 	SoundIsPlaying = FALSE;
@@ -2102,7 +2114,8 @@ void SoundFlush()
 	// 	txwfu = NULL;
 	// }
 
-	OpenSoundCapture(SavedCaptureDevice, SavedCaptureRate, strFault);
+	if (strcmp(PlaybackDevice, "NOSOUND") != 0)
+		OpenSoundCapture(SavedCaptureDevice, SavedCaptureRate, strFault);
 	StartCapture();
 
 	if (WriteRxWav)

--- a/ARDOPCommonCode/Waveout.c
+++ b/ARDOPCommonCode/Waveout.c
@@ -671,6 +671,15 @@ int InitSound(BOOL Report)
 			}
 		}
 	}
+	if (PlayBackIndex == -1) {
+		WriteDebugLog(LOGERROR,
+			"ERROR: playbackdevice = '%s' not found.  Try using one of the names or"
+			" numbers (0-%d) listed above.",
+			PlaybackDevice,
+			PlaybackCount - 1
+		);
+		return FALSE;
+	}
 
     ret = waveOutOpen(&hWaveOut, PlayBackIndex, &wfx, 0, 0, CALLBACK_NULL); //WAVE_MAPPER
 
@@ -697,6 +706,15 @@ int InitSound(BOOL Report)
 				break;
 			}
 		}
+	}
+	if (CaptureIndex == -1) {
+		WriteDebugLog(LOGERROR,
+			"ERROR: capturedevice = '%s' not found.  Try using one of the names or"
+			" numbers (0-%d) listed above.",
+			CaptureDevice,
+			CaptureCount - 1
+		);
+		return FALSE;
 	}
 
     ret = waveInOpen(&hWaveIn, CaptureIndex, &wfx, 0, 0, CALLBACK_NULL); //WAVE_MAPPER

--- a/ARDOPCommonCode/Waveout.c
+++ b/ARDOPCommonCode/Waveout.c
@@ -555,7 +555,8 @@ void txSleep(int mS)
 		WebguiPoll();
 	}
 
-	Sleep(mS);
+	if (strcmp(PlaybackDevice, "NOSOUND") != 0)
+		Sleep(mS);
 
 	if (PKTLEDTimer && Now > PKTLEDTimer)
     {
@@ -576,13 +577,17 @@ BOOL DMARunning = FALSE;		// Used to start DMA on first write
 
 short * SendtoCard(unsigned short * buf, int n)
 {
-	header[Index].dwBufferLength = n * 2;
-
-	waveOutPrepareHeader(hWaveOut, &header[Index], sizeof(WAVEHDR));
-	waveOutWrite(hWaveOut, &header[Index], sizeof(WAVEHDR));
-
 	if (txwff != NULL)
 		WriteWav(&buffer[Index][0], n, txwff);
+
+	if (strcmp(PlaybackDevice, "NOSOUND") == 0) {
+		Index = !Index;
+		return &buffer[Index][0];
+	}
+
+	header[Index].dwBufferLength = n * 2;
+	waveOutPrepareHeader(hWaveOut, &header[Index], sizeof(WAVEHDR));
+	waveOutWrite(hWaveOut, &header[Index], sizeof(WAVEHDR));
 
 	// wait till previous buffer is complete
 
@@ -652,6 +657,8 @@ void GetSoundDevices()
 int InitSound(BOOL Report)
 {
 	int i, ret;
+	if (strcmp(PlaybackDevice, "NOSOUND") == 0)
+		return TRUE;
 
 	header[0].dwFlags = WHDR_DONE;
 	header[1].dwFlags = WHDR_DONE;
@@ -747,6 +754,8 @@ UCHAR CurrentLevel = 0;		// Peak from current samples
 
 void PollReceivedSamples()
 {
+	if (strcmp(PlaybackDevice, "NOSOUND") == 0)
+		return;
 	// Process any captured samples
 	// Ideally call at least every 100 mS, more than 200 will loose data
 
@@ -1025,11 +1034,12 @@ void SoundFlush()
 	SendtoCard(buffer[Index], Number);
 
 	//	Wait for all sound output to complete
-	
-	while (!(header[0].dwFlags & WHDR_DONE))
-		txSleep(10);
-	while (!(header[1].dwFlags & WHDR_DONE))
-		txSleep(10);
+	if (strcmp(PlaybackDevice, "NOSOUND") != 0) {
+		while (!(header[0].dwFlags & WHDR_DONE))
+			txSleep(10);
+		while (!(header[1].dwFlags & WHDR_DONE))
+			txSleep(10);
+	}
 
 	// I think we should turn round the link here. I dont see the point in
 	// waiting for MainPoll
@@ -1150,7 +1160,8 @@ void PlatformSleep(int mS)
 {
 	//	Sleep to avoid using all cpu
 
-	Sleep(mS);
+	if (strcmp(PlaybackDevice, "NOSOUND") != 0)
+		Sleep(mS);
 		
 	if (PKTLEDTimer && Now > PKTLEDTimer)
     {


### PR DESCRIPTION
For testing purposes, it may be useful to run ardopcf without using a soundcard when generating test WAV file recordings.  In this configuration, it is not necessary to limit the production of audio samples to the rate at which the soundcard can play them.  Thus, WAV files can be produced more quickly using this feature.  To use this feature, specify NOSOUND as the name of the capture sound device.

This pull request also includes a related bugfix.  Before this fix, when running under Windows, if an invalid string was used to specify the playback or capture sound device, ardopcf failed to recognize this as an error.  With this fix, an error is printed and ardopcf exits when this occurs.