### PR TITLE
Restore missing license files for HIDAPI

### DIFF
--- a/lib/hid/LICENSE-orig.txt
+++ b/lib/hid/LICENSE-orig.txt
@@ -1,0 +1,9 @@
+ HIDAPI - Multi-Platform library for
+ communication with HID devices.
+
+ Copyright 2009, Alan Ott, Signal 11 Software.
+ All Rights Reserved.
+ 
+ This software may be used by anyone for any reason so
+ long as the copyright notice in the source files
+ remains intact.

--- a/lib/hid/LICENSE.txt
+++ b/lib/hid/LICENSE.txt
@@ -1,0 +1,13 @@
+HIDAPI can be used under one of three licenses.
+
+1. The GNU General Public License, version 3.0, in LICENSE-gpl3.txt
+2. A BSD-Style License, in LICENSE-bsd.txt.
+3. The more liberal original HIDAPI license. LICENSE-orig.txt
+
+The license chosen is at the discretion of the user of HIDAPI. For example:
+1. An author of GPL software would likely use HIDAPI under the terms of the
+GPL.
+
+2. An author of commercial closed-source software would likely use HIDAPI
+under the terms of the BSD-style license or the original HIDAPI license.
+


### PR DESCRIPTION
This adds/restores license files to the lib/hid directory containing files derived from software that can be found at https://github.com/signal11/hidapi by Alan Ott, Signal 11 Software.  That software is available under multiple licensing options, including the very liberal original license.  These license files should have been present all along.

Once this and the other contents of the develop branch are merged into the master branch, it is believed that ardopcf will have resolved all licensing errors previously present in this repository.