### PR TITLE
Test framework, fix 7-character callsigns not supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 ardopcf
 CalcTemplates
 /lib/txt2c/txt2c
+/test/ardop/*
+!/test/ardop/*.[ch]
+!/test/ardop/*.bin
 
 # temporary version of ardopSamples.c produced by CalcTemplates.
 newArdopSampleArrays.c
@@ -55,3 +58,6 @@ newArdopSampleArrays.c
 *.su
 *.idb
 *.pdb
+
+# Editor garbage
+/.vscode/**

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ OBJS = \
 	src/common/gen-webgui.js.o \
 	src/common/Webgui.o \
 
+OBJS_EXE = \
+	src/common/ardopcf.o \
+
 # Configuration:
 CPPFLAGS += -Isrc -Ilib
 CFLAGS = -g -MMD
@@ -64,7 +67,7 @@ endif
 
 all: ardopcf
 
-ardopcf: $(OBJS)
+ardopcf: $(OBJS_EXE) $(OBJS)
 	$(CC) $(LDFLAGS) $^ -o $@ $(LOADLIBES) $(LDLIBS)
 
 # if txt2c is not provided, build it
@@ -93,7 +96,14 @@ src/common/gen-%.c:: webgui/% | $(TXT2C)
 # 'make clean' before running 'make' to produce a successful build.  Failure
 # to run 'make clean' before using git checkout may sometimes leave build
 # related files that must then be manually deleted.
-CLEAN += ardopcf ardopcf.exe $(OBJS) $(OBJS:.o=.d) output.map
+CLEAN += \
+	ardopcf \
+	ardopcf.exe \
+	$(OBJS) \
+	$(OBJS:.o=.d) \
+	$(OBJS_EXE) \
+	$(OBJS_EXE:.o=.d) \
+	output.map \
 
 ifeq ($(OS),Windows_NT)
 # on Windows, del requires backslash paths

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 #	ardopcf Makefile
-#		For Linux, the default build requires only gcc and libraries typically
-#		installed by default.
-#			cd ardop/ARDOPC
+#		For Linux, the default build requires gcc, make, and development
+#		libraries for ALSA.
+#			sudo apt install build-essential libasound2-dev
 #			make
 #
 #		Fow Windows, the default build requires installation of a MinGW build
@@ -10,10 +10,32 @@
 #		build the Windows releases.  Installing these in `C:\Program Files` is
 #		not recommended since that may require admin privileges.  Other build
 #		environments may also work but are not tested.
-#			cd ardop\ARDOPC
 #			mingw32-make
+#
+#	`make test` which builds the executable and also runs some tests also
+#	requires installation of cmocka, which is not required for the default build.
+#		On Debian/Ubuntu this is easily installed with:
+#			sudo apt install libcmocka-dev
+#
+#		Package managers for other Linux distributions are also likely to
+#		provide easy installation of cmocka.
+#
+#		In the following description of how to install cmocka for Windows, a
+#		winlibs MinGW installation is assumed to be located at `C:\winlibs`
+#		If installed elsewhere, substitute the appropriate path.  Putting the
+#		cmocka files into the winlibs install directory avoids the need for further
+#		configuration.  This uses git (available from https://git-scm.com/downloads/win)
+#		to download the cmocka source code.
+#
+#		git clone https://git.cryptomilk.org/projects/cmocka.git
+#		cd cmocka
+#		mkdir build
+#		cd build
+#		cmake -G "MinGW Makefiles" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="C:\winlibs" ..
+#		mingw32-make
+#		mingw32-make install
 
-.PHONY: all
+.PHONY: all buildtest test
 
 # list all object files and their directories
 # keep sorted by filename
@@ -40,8 +62,23 @@ OBJS = \
 	src/common/gen-webgui.js.o \
 	src/common/Webgui.o \
 
+# user-facing executables, like ardopcf
 OBJS_EXE = \
 	src/common/ardopcf.o \
+
+# unit test executables
+TESTS = \
+	test/ardop/test_ARDOPC \
+
+# unit test common code
+TEST_OBJS_COMMON = \
+	test/ardop/setup.o \
+
+# define newline for use with foreach to run tests
+define newline
+
+
+endef
 
 # Configuration:
 CPPFLAGS += -Isrc -Ilib
@@ -89,6 +126,19 @@ endif
 src/common/gen-%.c:: webgui/% | $(TXT2C)
 	$(TXT2C) $< $@ $(subst .,_,$(notdir $<))
 
+# `make buildtest` builds the test-case executables but does not run them
+buildtest: $(TESTS)
+
+# `make test` prints the name of each test file and then runs that test.
+# running the test should indicate the tests run and whether they passed
+# or failed.
+test: buildtest
+	$(foreach test, $(TESTS), @echo $(test):$(newline)@$(test)$(newline))
+
+# rule to make test-case executables from their sources
+test/ardop/test_%: test/ardop/test_%.c $(OBJS) $(TEST_OBJS_COMMON)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $^ -o $@ $(LOADLIBES) $(LDLIBS) -lcmocka
+
 -include *.d
 
 # 'make clean' deletes files produced by the build process.
@@ -103,6 +153,11 @@ CLEAN += \
 	$(OBJS:.o=.d) \
 	$(OBJS_EXE) \
 	$(OBJS_EXE:.o=.d) \
+	$(TESTS) \
+	$(TESTS:%=%.exe) \
+	$(TESTS:%=%.d) \
+	$(TEST_OBJS_COMMON) \
+	$(TEST_OBJS_COMMON:.o=.d) \
 	output.map \
 
 ifeq ($(OS),Windows_NT)

--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -1668,13 +1668,32 @@ void ASCIIto6Bit(const char * Padded, UCHAR * Compressed)
 	// Input must be 8 bytes which will convert to 6 bytes of packed 6 bit characters and
 	// inputs must be the ASCII character set values from 32 to 95....
 
+	// Ensure string is exactly 8 characters long, right-padding with spaces
+	char work[9];
+	snprintf(work, sizeof(work), "%-8s", Padded ? Padded : "");
+
+	// Filter invalid characters
+	for (size_t pos = 0; pos < sizeof(work) - 1; ++pos) {
+		if (work[pos] >= ' ' && work[pos] <= '_') {
+			// pass
+		}
+		else if (work[pos] >= 'a' && work[pos] <= 'z') {
+			// to ascii uppercase
+			work[pos] = work[pos] - 32;
+		}
+		else {
+			// filter
+			work[pos] = ' ';
+		}
+	}
+
 	unsigned long long intSum = 0;
 
 	int i;
 
 	for (i=0; i<4; i++)
 	{
-		intSum = (64 * intSum) + Padded[i] - 32;
+		intSum = (64 * intSum) + work[i] - 32;
 	}
 
 	Compressed[0] = (UCHAR)(intSum >> 16) & 255;
@@ -1685,7 +1704,7 @@ void ASCIIto6Bit(const char * Padded, UCHAR * Compressed)
 
 	for (i=4; i<8; i++)
 	{
-		intSum = (64 * intSum) + Padded[i] - 32;
+		intSum = (64 * intSum) + work[i] - 32;
 	}
 
 	Compressed[3] = (UCHAR)(intSum >> 16) & 255;

--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -35,9 +35,9 @@ const char ProductName[] = "ardopcf";
 UCHAR bytDataToSend[DATABUFFERSIZE];
 int bytDataToSendLength = 0;
 
-void CompressCallsign(char * Callsign, UCHAR * Compressed);
+void CompressCallsign(const char *Callsign, UCHAR *Compressed);
 void CompressGridSquare(char * Square, UCHAR * Compressed);
-void  ASCIIto6Bit(char * Padded, UCHAR * Compressed);
+void ASCIIto6Bit(const char * Padded, UCHAR * Compressed);
 void GetTwoToneLeaderWithSync(int intSymLen);
 void SendID(BOOL blnEnableCWID);
 void PollReceivedSamples();
@@ -1663,7 +1663,7 @@ void Send5SecTwoTone()
 }
 
 
-void  ASCIIto6Bit(char * Padded, UCHAR * Compressed)
+void ASCIIto6Bit(const char * Padded, UCHAR * Compressed)
 {
 	// Input must be 8 bytes which will convert to 6 bytes of packed 6 bit characters and
 	// inputs must be the ASCII character set values from 32 to 95....
@@ -1693,7 +1693,7 @@ void  ASCIIto6Bit(char * Padded, UCHAR * Compressed)
 	Compressed[5] = (UCHAR)intSum & 255;
 }
 
-void Bit6ToASCII(UCHAR * Padded, UCHAR * UnCompressed)
+void Bit6ToASCII(const UCHAR * Padded, UCHAR * UnCompressed)
 {
 	// uncompress 6 to 8
 
@@ -1730,37 +1730,34 @@ void Bit6ToASCII(UCHAR * Padded, UCHAR * UnCompressed)
 
 // Function to compress callsign (up to 7 characters + optional "-"SSID   (-0 to -15 or -A to -Z)
 
-void CompressCallsign(char * inCallsign, UCHAR * Compressed)
+void CompressCallsign(const char * inCallsign, UCHAR * Compressed)
 {
-	char Callsign[10] = "";
-	char Padded[16];
-	int SSID;
-	char * Dash;
+	const char* inp = inCallsign ? inCallsign : "";
+	char work[9];
 
-	memcpy(Callsign, inCallsign, 10);
-	Dash = strchr(Callsign, '-');
+	// split string at SSID separator
+	size_t callsign_len = strcspn(inp, "-");
+	if (callsign_len > 7)
+		callsign_len = 7;
 
-	if (Dash == 0)  // if No SSID
-	{
-		strcpy(Padded, Callsign);
-		strcat(Padded, "    ");
-		Padded[7] = '0';  // "0" indicates no SSID
-	}
-	else
-	{
-		*(Dash++) = 0;
-		SSID = atoi(Dash);
+	// format the non-SSID part, right-padding with spaces
+	snprintf(work, sizeof(work), "%-7.*s0", (int)callsign_len, inp);
 
-		strcpy(Padded, Callsign);
-		strcat(Padded, "    ");
+	// read SSID if present
+	if (callsign_len > 0 && inp[callsign_len] == '-') {
+		char ssid = inp[callsign_len + 1];
+		int ssid_numeric = atoi(&inp[callsign_len + 1]);
+		if (ssid_numeric >= 10 && ssid_numeric <= 15)
+		{
+			// map SSID -10 to -15 to : ; < = > ?
+			ssid = ':' + ssid_numeric - 10;
+		}
 
-		if (SSID >= 10)  // handles special case of -10 to -15 : ; < = > ?
-			Padded[7] = ':' + SSID - 10;
-		else
-			Padded[7] = *(Dash);
+		// the SSID is always the last character of the compression buffer
+		work[7] = ssid;
 	}
 
-	ASCIIto6Bit(Padded, Compressed);  // compress to 8 6 bit characters   6 bytes total
+	ASCIIto6Bit(work, Compressed); // compress to 8 6 bit characters   6 bytes total
 }
 
 // Function to compress Gridsquare (up to 8 characters)
@@ -1780,25 +1777,34 @@ void CompressGridSquare(char * Square, UCHAR * Compressed)
 
 // Function to decompress 6 byte call sign to 7 characters plus optional -SSID of -0 to -15 or -A to -Z
 
-void DeCompressCallsign(char * bytCallsign, char * returned)
+void DeCompressCallsign(const char * bytCallsign, char * returned, size_t returnlen)
 {
-	char bytTest[10] = "";
-	char SSID[8] = "";
+	char work[9] = "";
+	Bit6ToASCII(bytCallsign, work);
 
-	Bit6ToASCII(bytCallsign, bytTest);
+	// the last byte is reserved for the SSID
+	char ssid = work[7];
+	work[7] = '\0';
 
-	memcpy(returned, bytTest, 7);
-	returned[7] = 0;
-	strlop(returned, ' ');  // remove trailing space
+	// trim any padding
+	size_t callsign_len = strcspn(work, " ");
 
-	if (bytTest[7] == '0')  // Value of "0" so No SSID
-		returned[6] = 0;
-	else if (bytTest[7] >= 58 && bytTest[7] <= 63)  // handles special case for -10 to -15
-		sprintf(SSID, "-%d", bytTest[7] - 48);
+	int ssid_numeric = 0;
+	if (ssid == '0') {
+		// no ssid
+		snprintf(returned, returnlen, "%.*s", (int)callsign_len, work);
+	}
+	else if (ssid >= ':' && ssid <= '?')
+	{
+		// numeric ssid
+		ssid_numeric = ssid - ':' + 10;
+		snprintf(returned, returnlen, "%.*s-%d", (int)callsign_len, work, ssid_numeric);
+	}
 	else
-		sprintf(SSID, "-%c", bytTest[7]);
-
-	strcat(returned, SSID);
+	{
+		// alphabetical ssid
+		snprintf(returned, returnlen, "%.*s-%c", (int)callsign_len, work, ssid);
+	}
 }
 
 

--- a/src/common/ARDOPC.h
+++ b/src/common/ARDOPC.h
@@ -215,8 +215,7 @@ void InitValidFrameTypes();
 extern void Generate50BaudTwoToneLeaderTemplate();
 extern BOOL blnDISCRepeating;
 
-BOOL DemodDecode4FSKID(UCHAR bytFrameType, char * strCallID, char * strGridSquare);
-void DeCompressCallsign(char * bytCallsign, char * returned);
+void DeCompressCallsign(const char * bytCallsign, char * returned, size_t returnlen);
 void DeCompressGridSquare(char * bytGS, char * returned);
 void ProcessRcvdFECDataFrame(int intFrameType, UCHAR * bytData, BOOL blnFrameDecodedOK);
 void ProcessUnconnectedConReqFrame(int intFrameType, UCHAR * bytData);

--- a/src/common/SoundInput.c
+++ b/src/common/SoundInput.c
@@ -2692,9 +2692,9 @@ BOOL Decode4FSKConReq()
 		FrameOK = FALSE;
 	}
 	memcpy(bytCall, bytFrameData1, 6);
-	DeCompressCallsign(bytCall, strCaller);
+	DeCompressCallsign(bytCall, strCaller, sizeof(strCaller));
 	memcpy(bytCall, &bytFrameData1[6], 6);
-	DeCompressCallsign(bytCall, strTarget);
+	DeCompressCallsign(bytCall, strTarget, sizeof(strTarget));
 
 //	printtick(strCaller);
 //	printtick(strTarget);
@@ -2804,9 +2804,9 @@ BOOL Decode4FSKPing()
 	}
 
 	memcpy(bytCall, bytFrameData1, 6);
-	DeCompressCallsign(bytCall, strCaller);
+	DeCompressCallsign(bytCall, strCaller, sizeof(strCaller));
 	memcpy(bytCall, &bytFrameData1[6], 6);
-	DeCompressCallsign(bytCall, strTarget);
+	DeCompressCallsign(bytCall, strTarget, sizeof(strTarget));
 
 //	printtick(strCaller);
 //	printtick(strTarget);
@@ -2923,7 +2923,7 @@ BOOL Decode4FSKPingACK(UCHAR bytFrameType, int * intSNdB, int * intQuality)
 }
 
 
-BOOL Decode4FSKID(UCHAR bytFrameType, char * strCallID, char * strGridSquare)
+BOOL Decode4FSKID(UCHAR bytFrameType, char * strCallID, size_t strCallIDLen, char * strGridSquare)
 {
 	UCHAR bytCall[10];
 	UCHAR temp[20];
@@ -2958,7 +2958,7 @@ BOOL Decode4FSKID(UCHAR bytFrameType, char * strCallID, char * strGridSquare)
 	}
 
 	memcpy(bytCall, bytFrameData1, 6);
-	DeCompressCallsign(bytCall, strCallID);
+	DeCompressCallsign(bytCall, strCallID, strCallIDLen);
 	memcpy(bytCall, &bytFrameData1[6], 6);
 	DeCompressGridSquare(bytCall, temp);
 
@@ -3241,7 +3241,7 @@ BOOL DecodeFrame(int xxx, UCHAR * bytData)
 
 		case 0x30:  // ID Frame,
 
-			blnDecodeOK = Decode4FSKID(0x30, strIDCallSign, strGridSQ);
+			blnDecodeOK = Decode4FSKID(0x30, strIDCallSign, sizeof(strIDCallSign), strGridSQ);
 
 			frameLen = sprintf(bytData, "ID:%s %s:" , strIDCallSign, strGridSQ);
 

--- a/src/common/ardopcf.c
+++ b/src/common/ardopcf.c
@@ -1,0 +1,12 @@
+/*
+ * ardopcf main function
+ *
+ * Invokes the platform-specific main function from either
+ * ALSASound.c (Linux) or Waveout.c (Windows)
+ */
+int platform_main(int argc, char *argv[]);
+
+int main(int argc, char *argv[])
+{
+	return platform_main(argc, argv);
+}

--- a/src/common/ardopcommon.h
+++ b/src/common/ardopcommon.h
@@ -213,8 +213,7 @@ void setProtocolMode(char* strMode);
 extern void Generate50BaudTwoToneLeaderTemplate();
 extern BOOL blnDISCRepeating;
 
-BOOL DemodDecode4FSKID(UCHAR bytFrameType, char * strCallID, char * strGridSquare);
-void DeCompressCallsign(char * bytCallsign, char * returned);
+void DeCompressCallsign(const char * bytCallsign, char * returned, size_t returnedlen);
 void DeCompressGridSquare(char * bytGS, char * returned);
 
 int RSEncode(UCHAR * bytToRS, UCHAR * bytRSEncoded, int MaxErr, int Len);

--- a/src/linux/ALSASound.c
+++ b/src/linux/ALSASound.c
@@ -513,7 +513,7 @@ static void sigint_handler(int sig)
 char * PortString = NULL;
 
 
-int main(int argc, char * argv[])
+int platform_main(int argc, char * argv[])
 {
 	struct timespec tp;
 	struct sigaction act;

--- a/src/windows/Waveout.c
+++ b/src/windows/Waveout.c
@@ -344,7 +344,7 @@ BOOL CtrlHandler(DWORD fdwCtrlType)
 
 
 
-int main(int argc, char * argv[])
+int platform_main(int argc, char * argv[])
 {
 	TIMECAPS tc;
 	unsigned int     wTimerRes;

--- a/test/ardop/setup.c
+++ b/test/ardop/setup.c
@@ -1,0 +1,10 @@
+#include "setup.h"
+
+// log level constants
+extern int FileLogLevel;
+extern int ConsoleLogLevel;
+
+void ardop_test_setup() {
+    FileLogLevel = 0;
+    ConsoleLogLevel = 0;
+}

--- a/test/ardop/setup.h
+++ b/test/ardop/setup.h
@@ -1,0 +1,13 @@
+#ifndef _TEST_ARDOP_SETUP_H
+#define _TEST_ARDOP_SETUP_H
+
+/**
+ * @brief Setup routines common to all ARDOP test executables
+ *
+ * All ARDOP unit test executables should invoke this method
+ * once before any tests are executed. This method configures
+ * ARDOP logging and any other global state.
+ */
+void ardop_test_setup();
+
+#endif

--- a/test/ardop/test_ARDOPC.c
+++ b/test/ardop/test_ARDOPC.c
@@ -1,0 +1,126 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <string.h>
+#include <cmocka.h>
+
+#include "setup.h"
+
+#include "common/ARDOPC.h"
+
+void DeCompressCallsign(char *bytCallsign, char *returned);
+void CompressCallsign(char *Callsign, UCHAR *Compressed);
+
+/*
+ * Check that the given `call`sign (with optional SSID) has the given
+ * compressed `hexstr` representation in the ARDOP protocol. The given
+ * `hexstr` must be 12 characters of hexadecimal like "b908e1b2c010"
+ */
+static void assert_callsign_wireline_is(const char *call, const char *hexstr)
+{
+	char inbuf[32];
+	UCHAR compressed[6];
+	char compressed_hex[2*sizeof(compressed) + 1];
+	compressed_hex[2 * sizeof(compressed)] = '\0';
+
+	// check string must be exactly 12 characters long
+	assert_int_equal(strlen(hexstr), 2 * sizeof(compressed));
+
+	snprintf(inbuf, sizeof(inbuf), "%s", call);
+
+	CompressCallsign(inbuf, compressed);
+
+	for (size_t i = 0; i < sizeof(compressed); ++i) {
+		snprintf(&compressed_hex[2*i], 3, "%02x", (unsigned int)compressed[i]);
+	}
+	assert_string_equal(hexstr, compressed_hex);
+}
+
+/*
+ * Verify that the given `call_in` callsign (with optional SSID) becomes
+ * `call_out` after a round-trip through the callsign compress/decompress
+ * algorithm. This verifies that the callsign can be sent and received.
+ */
+static void assert_callsign_inout(const char *call_in, const char *call_out)
+{
+	char inbuf[32];
+	char out[11];
+	UCHAR compressed[6];
+
+	snprintf(inbuf, sizeof(inbuf), "%s", call_in);
+
+	CompressCallsign(inbuf, compressed);
+	DeCompressCallsign(compressed, out);
+	assert_string_equal(call_out, out);
+}
+
+/*
+ * test callsign wireline representation
+ *
+ * All callsigns were manually tested by sending an IDFrame whose contents
+ * were encoded using CompressCallsign() to ARDOP_WIN v 1.0.2.6 where the
+ * received callsign was read from the Rcv Frame field of the associated
+ * ardop gui.
+ *
+ * All values matched the expected result except for "LONGCAL-15" which
+ * was displayed as "LONGCAL-1". It is unknown at this time whether that
+ * exception actually indicates that ARDOP_WIN actually decoded it
+ * incorrectly, or whether the ardop gui simply failed to display it
+ * properly.
+ */
+static void test_compress_callsign(void **state)
+{
+	(void)state; /* unused */
+
+	// six character + SSID values are taken from direct
+	// invocation of CompressCallsign() in ardopcf eab1f3165a30.
+	assert_callsign_wireline_is("A1A", "851840000010");
+	assert_callsign_wireline_is("A1A-1", "851840000011");
+	assert_callsign_wireline_is("N0CALL", "b908e1b2c010");
+	assert_callsign_wireline_is("N0CALL-A", "b908e1b2c021");
+	assert_callsign_wireline_is("N0CALL-Z", "b908e1b2c03a");
+
+	// non-canonical representation
+	assert_callsign_wireline_is("N0CALL-0", "b908e1b2c010");
+}
+
+/* test callsign round-trip through the protocol */
+static void test_decompress_callsign(void **state)
+{
+	(void)state; /* unused */
+
+	assert_callsign_inout("A1A", "A1A");
+	assert_callsign_inout("A1A-1", "A1A-1");
+	assert_callsign_inout("N0CALL", "N0CALL");
+	assert_callsign_inout("N0CALL-A", "N0CALL-A");
+	assert_callsign_inout("N0CALL-Z", "N0CALL-Z");
+	// assert_callsign_inout("LONGCAL-15", "LONGCAL-15"); /* ASAN */
+
+	// non-canonical representation
+	assert_callsign_inout("N0CALL-0", "N0CALL");
+
+	// too long callsign
+	assert_callsign_inout("CAFECAFE", "CAFECAF");
+
+	// overflow
+	assert_callsign_inout("MUCHTOOLON-G", "MUCHTOO");
+
+	// ssid out of numeric range is truncated
+	assert_callsign_inout("N0CALL-16", "N0CALL-1");
+
+	// empty
+	assert_callsign_inout("", "");
+	assert_callsign_inout(NULL, "");
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_compress_callsign),
+		cmocka_unit_test(test_decompress_callsign),
+	};
+
+	ardop_test_setup();
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
This PR adds cmocka-based unit tests to ardopcf.

I selected some simple functions that looked unsafe and wrote some tests for them:

* [`CompressCallsign()`](https://github.com/pflarue/ardop/blob/master/ARDOPC/ARDOPC.c#L1879); and
* [`DeCompressCallsign()`](https://github.com/pflarue/ardop/blob/master/ARDOPC/ARDOPC.c#L1929)

In the process of writing these tests, I discovered that 7-character callsigns do not appear to work. The second commit in this patch series demonstrates this.

```log
$ sudo apt install libcmocka-dev    # required prerequisite
$ make test
tests/test_ARDOPC:
[==========] Running 2 test(s).
[ RUN      ] test_compress_callsign
[       OK ] test_compress_callsign
[ RUN      ] test_decompress_callsign
[  ERROR   ] --- "CAFECAF" != "CAFECA"
[   LINE   ] --- tests/test_ARDOPC.c:56: error: Failure!
[  FAILED  ] test_decompress_callsign
[==========] 2 test(s) run.
[  PASSED  ] 1 test(s).
[  FAILED  ] 1 test(s), listed below:
[  FAILED  ] test_decompress_callsign
```

The spec requires support for three- to seven-character callsigns + SSID.

The HEAD commit in this PR proposes a fix. I am not sure if the fix is compatible with other ARDOP implementations. Tests verify that we have left six-character wireline representations unchanged.

These changes support the following eventual goals:

* Eliminate gcc 13 compiler warnings
* Eliminate unbounded string functions like `sprintf()` and `strcat()`
* Pass buffer sizes to all functions that produce variable-length output
* Add `const`-correctness guarantees where easy and appropriate

Closes #30