### PR TITLE
Calc templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Executables
 /ARDOPC/ardopcf
 /ARDOPC/webgui/txt2c
+/ARDOPC/CalcTemplates
+
+# temporary version of ardopSamples.c produced by CalcTemplates.
+/ARDOPC/newArdopSampleArrays.c
 
 # Log files
 *.log

--- a/ARDOPC/CalcTemplates.c
+++ b/ARDOPC/CalcTemplates.c
@@ -1,3 +1,9 @@
+#include <stdio.h>
+#include <math.h>
+
+// Compile along with ardopSampleArrays.c so that results can be compared:
+// gcc -o CalcTemplates CalcTemplates.c ardopSampleArrays.c -lm
+
 //
 // This code calculates and writes to files the templates
 // used to generate modulation samples.
@@ -11,12 +17,26 @@
 
 // Keep code in case we need to change, but don't compile
 
-#if 0
-
-#include "ARDOPC.h"
+FILE * fout;
 
 #pragma warning(disable : 4244)		// Code does lots of int float to int
 
+// These are the values found in the existing ardopSampleArrays.c
+// Newly calculated values will be compared to these so that a summary
+// of the resulting changes can be printed
+extern const short int50BaudTwoToneLeaderTemplate[120];
+extern const short intFSK50bdCarTemplate[4][240];
+extern const short intFSK600bdCarTemplate[4][20];
+extern const short intFSK100bdCarTemplate[4][120];
+extern const short intPSK100bdCarTemplate[9][4][120];
+
+// These are the new values being calclated.
+// They will be written to newArdopSamples.c
+short intNew50BaudTwoToneLeaderTemplate[120];
+short intNewFSK50bdCarTemplate[4][240];
+short intNewFSK600bdCarTemplate[4][20];
+short intNewFSK100bdCarTemplate[4][120];
+short intNewPSK100bdCarTemplate[9][4][120];
 
 static int intAmp = 26000;	   // Selected to have some margin in calculations with 16 bit values (< 32767) this must apply to all filters as well. 
 
@@ -26,12 +46,17 @@ void Generate50BaudTwoToneLeaderTemplate()
 	float x, y, z;
 	int line = 0;
 
-	FILE * fp1;
-
-	char msg[80];
+	char msg[256];
 	int len;
+	char suffix[10] = "";
 
-	fp1 = fopen("s:\\leadercoeffs.txt", "wb");
+	len = sprintf(msg,
+		"// These Templates are used to save lots of calculations when\n"
+		"// generating samples. They are pre-calculated by CalcTemplates.c.\n\n"
+		"// Template for 1 symbol (20 ms) of the 50 Baud leader.\n"
+		"const short int50BaudTwoToneLeaderTemplate[240] = {\n"
+	);
+	fwrite(msg, 1, len, fout);
 
 	for (i = 0; i < 240; i++)
 	{
@@ -39,38 +64,46 @@ void Generate50BaudTwoToneLeaderTemplate()
 		z = (sin(((1500.0 + 25) / 1500) * (i / 8.0 * 2 * M_PI)));
 
 		x = intAmp * 0.55 * (y - z);
-		int50BaudTwoToneLeaderTemplate[i] = (short)x + 0.5;
+		// The following previously used (short)x + 0.5
+		// I believe it was intended to be (short)(x + 0.5) so as to use an
+		// offset by 1/2 before truncate to get the effect of (short)round(x).
+		// However, that would also be incorrect where x < 0.
+		// So, I believe that this is an improvement, albeit minor one. --LaRue
+		intNew50BaudTwoToneLeaderTemplate[i] = (short)round(x);
 
 		if ((i - line) == 9)
 		{
 			// print the last 10 values
-
-			len = sprintf(msg, "\t%d, %d, %d, %d, %d, %d, %d, %d, %d, %d\n",
-				int50BaudTwoToneLeaderTemplate[line],
-				int50BaudTwoToneLeaderTemplate[line + 1],
-				int50BaudTwoToneLeaderTemplate[line + 2],
-				int50BaudTwoToneLeaderTemplate[line + 3],
-				int50BaudTwoToneLeaderTemplate[line + 4],
-				int50BaudTwoToneLeaderTemplate[line + 5],
-				int50BaudTwoToneLeaderTemplate[line + 6],
-				int50BaudTwoToneLeaderTemplate[line + 7],
-				int50BaudTwoToneLeaderTemplate[line + 8],
-				int50BaudTwoToneLeaderTemplate[line + 9]);
+			if (i + 1 == 240)
+				sprintf(suffix, "};\n\n");
+			else
+				sprintf(suffix, ",\n");
+			len = sprintf(msg, "\t%d, %d, %d, %d, %d, %d, %d, %d, %d, %d%s",
+				intNew50BaudTwoToneLeaderTemplate[line],
+				intNew50BaudTwoToneLeaderTemplate[line + 1],
+				intNew50BaudTwoToneLeaderTemplate[line + 2],
+				intNew50BaudTwoToneLeaderTemplate[line + 3],
+				intNew50BaudTwoToneLeaderTemplate[line + 4],
+				intNew50BaudTwoToneLeaderTemplate[line + 5],
+				intNew50BaudTwoToneLeaderTemplate[line + 6],
+				intNew50BaudTwoToneLeaderTemplate[line + 7],
+				intNew50BaudTwoToneLeaderTemplate[line + 8],
+				intNew50BaudTwoToneLeaderTemplate[line + 9],
+				suffix);
 
 			line = i + 1;
 
-			fwrite(msg, 1, len, fp1);
+			fwrite(msg, 1, len, fout);
 		}
-	}		
-	fclose(fp1);
+	}
 }
 
 // Subroutine to create the FSK symbol templates
 
 void GenerateFSKTemplates()
 {
-	// Generate templates of 240 samples (each symbol template = 20 ms) for each of the 4 possible carriers used in 200 Hz BW FSK modulation.
-	// Generate templates of 120 samples (each symbol template = 10 ms) for each of the 20 possible carriers used in 500, 1000 and 2000 Hz BW 4FSK modulation.
+	// Generate templates of 240 samples (each symbol template = 20 ms) for each of the 4 possible carriers used in 200 Hz BW 4FSK modulation.
+	// Generate templates of 120 samples (each symbol template = 10 ms) for each of the 4 possible carriers used in 500 Hz BW 4FSK modulation.
 	//Used to speed up computation of FSK frames and reduce use of Sin functions.
 	//50 baud Tone values 
 
@@ -82,18 +115,24 @@ void GenerateFSKTemplates()
 	int i, k;
 
 	char msg[256];
+	char prefix[10] = "";
+	char suffix[10] = "";
 	int len;
 	int line = 0;
-	FILE * fp1;
 
 	// Compute the phase inc per sample
+	len = sprintf(msg,
+		"// Template for 4FSK carriers spaced at 50 Hz, 50 baud\n\n"
+		"const short intFSK50bdCarTemplate[4][240] = {\n"
+	);
+	fwrite(msg, 1, len, fout);
 
     for (i = 0; i < 4; i++) 
 	{
 		dblCarPhaseInc[i] = 2 * M_PI * dblCarFreq[i] / 12000;
 	}
 	
-	// Now compute the templates: (960 32 bit values total) 
+	// Now compute the templates: (960 16 bit values total)
 	
 	for (i = 0; i < 4; i++)			// across the 4 tones for 50 baud frequencies
 	{
@@ -104,7 +143,9 @@ void GenerateFSKTemplates()
 
 		for (k = 0; k < 240; k++)	// for 240 samples (one 50 baud symbol)
 		{
-			intFSK50bdCarTemplate[i][k] = intAmp * 1.1 * sin(dblAngle);  // with no envelope control (factor 1.1 chosen emperically to keep FSK peak amplitude slightly below 2 tone peak)
+			// with no envelope control (factor 1.1 chosen emperically to keep
+			// FSK peak amplitude slightly below 2 tone peak)
+			intNewFSK50bdCarTemplate[i][k] = intAmp * 1.1 * sin(dblAngle);
 			dblAngle += dblCarPhaseInc[i];
 
 			if (dblAngle >= 2 * M_PI)
@@ -113,41 +154,34 @@ void GenerateFSKTemplates()
 			if ((k - line) == 9)
 			{
 				// print the last 10 values
-
-				len = sprintf(msg, "\t%d, %d, %d, %d, %d, %d, %d, %d, %d, %d,\n",
-				intFSK50bdCarTemplate[i][line],
-				intFSK50bdCarTemplate[i][line + 1],
-				intFSK50bdCarTemplate[i][line + 2],
-				intFSK50bdCarTemplate[i][line + 3],
-				intFSK50bdCarTemplate[i][line + 4],
-				intFSK50bdCarTemplate[i][line + 5],
-				intFSK50bdCarTemplate[i][line + 6],
-				intFSK50bdCarTemplate[i][line + 7],
-				intFSK50bdCarTemplate[i][line + 8],
-				intFSK50bdCarTemplate[i][line + 9]);
+				if (line == 0)
+					sprintf(prefix, "\t{");
+				else
+					sprintf(prefix, "\t");
+				if (i == 3 && k + 1 == 240)
+					sprintf(suffix, "}\n};\n\n\n");
+				else if (k + 1 == 240)
+					sprintf(suffix, "},\n\n");
+				else
+					sprintf(suffix, ",\n");
+				len = sprintf(msg, "%s%d, %d, %d, %d, %d, %d, %d, %d, %d, %d%s",
+				prefix,
+				intNewFSK50bdCarTemplate[i][line],
+				intNewFSK50bdCarTemplate[i][line + 1],
+				intNewFSK50bdCarTemplate[i][line + 2],
+				intNewFSK50bdCarTemplate[i][line + 3],
+				intNewFSK50bdCarTemplate[i][line + 4],
+				intNewFSK50bdCarTemplate[i][line + 5],
+				intNewFSK50bdCarTemplate[i][line + 6],
+				intNewFSK50bdCarTemplate[i][line + 7],
+				intNewFSK50bdCarTemplate[i][line + 8],
+				intNewFSK50bdCarTemplate[i][line + 9],
+				suffix);
 
 				line = k + 1;
 
-//				fwrite(msg, 1, len, fp1);
+				fwrite(msg, 1, len, fout);
 			}
-		}
-	}
-
-
-	// 4FSK templates for 600 baud (2 Khz bandwidth) 
-	for (i = 0; i < 4; i++)		 // across the 4 tones for 600 baud frequencies
-	{
-		dblAngle = 0;
-		//600 baud template
-		for (k = 0; k < 20; k++)	 // for 20 samples (one 600 baud symbol)
-		{
-			int xx = intAmp * 1.1 * sin(dblAngle); // with no envelope control (factor 1.1 chosen emperically to keep FSK peak amplitude slightly below 2 tone peak)
-			if (intFSK600bdCarTemplate[i][k] != xx)
-				printf("Duff\n");
-
-			dblAngle += (2 * M_PI / 12000) * (600 + i * 600);
-			if (dblAngle >= 2 * M_PI)
-				dblAngle -= 2 * M_PI;
 		}
 	}
 
@@ -167,17 +201,18 @@ void GenerateFSKTemplates()
 		dblCarPhaseInc[i] = 2 * M_PI * dblCarFreq[i] / 12000;
 	}
 
-	// Now compute the templates: (2400 32 bit values total)  
+	// Now compute the templates: (480 16 bit values total)
 
-	for (i = 0; i < 4; i++)	 // across 20 tones
+	for (i = 0; i < 4; i++)	 // across 4 tones
 	{
 		dblAngle = 0;
 		//'100 baud template
 		for (k = 0; k < 120; k++)		// for 120 samples (one 100 baud symbol)
 		{
 			short work = intAmp * 1.1 * sin(dblAngle);
-			intFSK100bdCarTemplate[i][k] = work; // with no envelope control (factor 1.1 chosen emperically to keep FSK peak amplitude slightly below 2 tone peak)
-				
+			// with no envelope control (factor 1.1 chosen emperically to keep
+			// FSK peak amplitude slightly below 2 tone peak)
+			intNewFSK100bdCarTemplate[i][k] = work;
 			dblAngle += dblCarPhaseInc[i];
 			if (dblAngle >= 2 * M_PI)
 				dblAngle -= 2 * M_PI;
@@ -186,63 +221,90 @@ void GenerateFSKTemplates()
 
 
 	// Now print them
+	len = sprintf(msg,
+		"// obsolete versions of this code accommodated multi-carrier FSK.\n"
+		"// Template for 4FSK carriers spaced at 100 Hz, 100 baud\n\n"
+		"const short intFSK100bdCarTemplate[4][120] = {\n"
+	);
+	fwrite(msg, 1, len, fout);
 
-
-	fp1 = fopen("s:\\fskcoeffs100.txt", "wb");
-
-	len = sprintf(msg, "short intFSK100bdCarTemplate[4][120] = \r\n");
-	fwrite(msg, 1, len, fp1);
-
-	len = sprintf(msg, "\t{{\r\n");
-	fwrite(msg, 1, len, fp1);
-
-	for (i = 0; i < 4; i++)		// across 9 tones
+	for (i = 0; i < 4; i++)		// across 4 tones
 	{
 			line = 0;
 
-			for (k = 0; k <= 119; k++) // for 120 samples (one 100 baud symbol, 200 baud modes will just use half of the data)
+			for (k = 0; k <= 119; k++) // for 120 samples (one 100 baud symbol)
 			{
 				if ((k - line) == 9)
 				{
 					// print 10 to line
-
-					len = sprintf(msg, "\t%d, %d, %d, %d, %d, %d, %d, %d, %d, %d,\n",
-					intFSK100bdCarTemplate[i][line],
-					intFSK100bdCarTemplate[i][line + 1],
-					intFSK100bdCarTemplate[i][line + 2],
-					intFSK100bdCarTemplate[i][line + 3],
-					intFSK100bdCarTemplate[i][line + 4],
-					intFSK100bdCarTemplate[i][line + 5],
-					intFSK100bdCarTemplate[i][line + 6],
-					intFSK100bdCarTemplate[i][line + 7],
-					intFSK100bdCarTemplate[i][line + 8],
-					intFSK100bdCarTemplate[i][line + 9]);
+					if (line == 0)
+						sprintf(prefix, "\t{");
+					else
+						sprintf(prefix, "\t");
+					if (i == 3 && k + 1 == 120)
+						sprintf(suffix, "}\n};\n\n\n");
+					else if (k + 1 == 120)
+						sprintf(suffix, "},\n\n");
+					else
+						sprintf(suffix, ",\n");
+					len = sprintf(msg, "%s%d, %d, %d, %d, %d, %d, %d, %d, %d, %d%s",
+					prefix,
+					intNewFSK100bdCarTemplate[i][line],
+					intNewFSK100bdCarTemplate[i][line + 1],
+					intNewFSK100bdCarTemplate[i][line + 2],
+					intNewFSK100bdCarTemplate[i][line + 3],
+					intNewFSK100bdCarTemplate[i][line + 4],
+					intNewFSK100bdCarTemplate[i][line + 5],
+					intNewFSK100bdCarTemplate[i][line + 6],
+					intNewFSK100bdCarTemplate[i][line + 7],
+					intNewFSK100bdCarTemplate[i][line + 8],
+					intNewFSK100bdCarTemplate[i][line + 9],
+					suffix);
 
 					line = k + 1;
-
-					if (k == 119)
-					{
-						len += sprintf(&msg[len-2], "},\r\n\r\n\t{");
-						len -=2;
-					}
-					fwrite(msg, 1, len, fp1);
+					fwrite(msg, 1, len, fout);
 				}
-	
 		}
 	}
 
-	len = sprintf(msg, "\t}};\r\n");
-	fwrite(msg, 1, len, fp1);
 
-	fclose(fp1);
+	// 600 baud Tone values for a single carrier case
+	// the 600 baud carrier frequencies in Hz
 
-	fp1 = fopen("s:\\fskcoeffs600.txt", "wb");
+	dblCarFreq[0] = 600;
+	dblCarFreq[1] = 1200;
+	dblCarFreq[2] = 1800;
+	dblCarFreq[3] = 2400;
 
-	len = sprintf(msg, "short intFSK600bdCarTemplate[4][20] = {\r\n");
-	fwrite(msg, 1, len, fp1);
+	// Compute the phase inc per sample
 
-	len = sprintf(msg, "\t{\r\n");
-	fwrite(msg, 1, len, fp1);
+	for (i = 0; i < 4; i++)
+	{
+		dblCarPhaseInc[i] = 2 * M_PI * dblCarFreq[i] / 12000;
+	}
+
+	// Now compute the templates:
+
+	for (i = 0; i < 4; i++)	 // across 20 tones
+	{
+		dblAngle = 0;
+		for (k = 0; k < 20; k++)		// for 20 samples (one 600 baud symbol)
+		{
+			short work = intAmp * 1.1 * sin(dblAngle);
+			// with no envelope control (factor 1.1 chosen emperically to keep
+			// FSK peak amplitude slightly below 2 tone peak)
+			intNewFSK600bdCarTemplate[i][k] = work;
+			dblAngle += dblCarPhaseInc[i];
+			if (dblAngle >= 2 * M_PI)
+				dblAngle -= 2 * M_PI;
+		}
+	}
+
+	len = sprintf(msg,
+		"// Template for 4FSK carriers spaced at 600 Hz, 600 baud"
+		"  (used for FM only)\n\n"
+		"const short intFSK600bdCarTemplate[4][20] = {\n");
+	fwrite(msg, 1, len, fout);
 
 	for (i = 0; i < 4; i++)		// across 4 tones
 	{
@@ -252,49 +314,41 @@ void GenerateFSKTemplates()
 				if ((k - line) == 9)
 				{
 					// print 10 to line
-
-					len = sprintf(msg, "\t%d, %d, %d, %d, %d, %d, %d, %d, %d, %d,\n",
-					intFSK600bdCarTemplate[i][line],
-					intFSK600bdCarTemplate[i][line + 1],
-					intFSK600bdCarTemplate[i][line + 2],
-					intFSK600bdCarTemplate[i][line + 3],
-					intFSK600bdCarTemplate[i][line + 4],
-					intFSK600bdCarTemplate[i][line + 5],
-					intFSK600bdCarTemplate[i][line + 6],
-					intFSK600bdCarTemplate[i][line + 7],
-					intFSK600bdCarTemplate[i][line + 8],
-					intFSK600bdCarTemplate[i][line + 9]);
+					if (line == 0)
+						sprintf(prefix, "\t{");
+					else
+						sprintf(prefix, "\t");
+					if (i == 3 && k + 1 == 20)
+						sprintf(suffix, "}\n};\n\n");
+					else if (k + 1 == 20)
+						sprintf(suffix, "},\n\n");
+					else
+						sprintf(suffix, ",\n");
+					len = sprintf(msg, "%s%d, %d, %d, %d, %d, %d, %d, %d, %d, %d%s",
+					prefix,
+					intNewFSK600bdCarTemplate[i][line],
+					intNewFSK600bdCarTemplate[i][line + 1],
+					intNewFSK600bdCarTemplate[i][line + 2],
+					intNewFSK600bdCarTemplate[i][line + 3],
+					intNewFSK600bdCarTemplate[i][line + 4],
+					intNewFSK600bdCarTemplate[i][line + 5],
+					intNewFSK600bdCarTemplate[i][line + 6],
+					intNewFSK600bdCarTemplate[i][line + 7],
+					intNewFSK600bdCarTemplate[i][line + 8],
+					intNewFSK600bdCarTemplate[i][line + 9],
+					suffix);
 
 					line = k + 1;
-
-					if (k == 19)
-					{
-						len += sprintf(&msg[len-2], "},\r\n\r\n\t{");
-						len -=2;
-					}
-					fwrite(msg, 1, len, fp1);
+					fwrite(msg, 1, len, fout);
 				}
-	
 		}
 	}
-
-	len = sprintf(msg, "\t}};\r\n");
-	fwrite(msg, 1, len, fp1);
-
-	fclose(fp1);
-
-
-
 }
 
 //	 Subroutine to initialize valid frame types 
 
-
-//	Subroutine to create the PSK symbol templates for 8 tones and 8 phases at 200 baud
-float round(float x);
-
 // obsolete versions of this code partially accommodated intBaud of 200 and 167 as well as 100.
-VOID GeneratePSKTemplates()
+void GeneratePSKTemplates()
 {
 	// Generate templates of 120 samples (each template = 10 ms) for each of the 9 possible carriers used in PSK modulation. 
 	// Used to speed up computation of PSK frames and reduce use of Sin functions.
@@ -304,10 +358,11 @@ VOID GeneratePSKTemplates()
 
 	int i, j ,k;
 	float dblCarFreq[]  = {800, 1000, 1200, 1400, 1500, 1600, 1800, 2000, 2200};
-	FILE * fp1;
-	char msg[256];
+	char msg[300];
 	int len;
 	int line = 0;
+	char prefix[10] = "";
+	char suffix[10] = "";
 
 	//  for 1 carrier modes use index 4 (1500)
 	//  for 2 carrier modes use indexes 3, 5 (1400 and 1600 Hz)
@@ -320,7 +375,6 @@ VOID GeneratePSKTemplates()
 
         //Dim dblPeakAmp As Double = intAmp * 0.5 ' may need to adjust 
 	
-	fp1 = fopen("d:\\PSKcoeffs.txt", "wb");
 
 		// Compute the phase inc per sample
 
@@ -329,30 +383,33 @@ VOID GeneratePSKTemplates()
 		dblCarPhaseInc[i] = 2 * M_PI * dblCarFreq[i] / 12000;
 	}
 
-	// Now compute the templates: (4320 32 bit values total) 
+	// Now compute the templates: (4320 16 bit values total)
 
 	for (i = 0; i <= 8; i++)		// across 9 tones
 	{
-		for (j = 0; j <= 3; j++)	// ( using only half the values and sign compliment for the opposit phases) 
+		for (j = 0; j <= 3; j++)	// ( using only half the values and sign compliment for the opposite phases)
 		{
 			dblAngle = 2 * M_PI * j / 8;
 			for (k = 0; k <= 119; k++) // for 120 samples (one 100 baud symbol)
 			{
-	//			float xx = intAmp * sin(M_PI * k / 119) * sin(dblAngle);
-	//			float xx2 = round(xx);
-	//			int xxi= (int)(xx2);
-				
-	//			if (intPSK100bdCarTemplate[i][j][k] != xxi)
-	////			{
-	//				k++;
-	//				k--;
-	//			}
-		
-				intPSK100bdCarTemplate[i][j][k] = (short)round(intAmp * sin(dblAngle));  // with no envelope control
-	          // intPSK100bdCarTemplate(i, j, k) = intAmp * Sin(PI * k / 119) * Sin(dblAngle) ' with envelope control using Sin
- 		
+				// This source file (CalcTemplates.c) was not functional as
+				// inherited from g8bpq/ardop, though most of the calculations
+				// were correctly implemented.  However, of the next two lines,
+				// the one marked as "with no envelope control" was used while
+				// the one marked as "with envelope control" was commented out.
+				// While that may have been "correct", it did not produce values
+				// which matched ardopSampleArrays.c as inherited from
+				// g8bpq/ardop.  So, for now, "with envelope control" it is
+				// enabled.  Whether this should be changed requires further
+				// evaluation.  -- LaRue (June 2024)
+
+				// with no envelope control
+				// intNewPSK100bdCarTemplate[i][j][k] = (short)round(intAmp * sin(dblAngle));
+
+				// with envelope control using Sin
+				intNewPSK100bdCarTemplate[i][j][k] = (short)round(intAmp * sin(M_PI * k / 119) * sin(dblAngle));
+
 				dblAngle += dblCarPhaseInc[i];
-				
 				if (dblAngle >= 2 * M_PI)
 					dblAngle -= 2 * M_PI;
 			}
@@ -361,60 +418,373 @@ VOID GeneratePSKTemplates()
 
 // Now print them
 
-	len = sprintf(msg, "\tshort intPSK100bdCarTemplate[9][4][120] = \r\n");
-	fwrite(msg, 1, len, fp1);
-
-	len = sprintf(msg, "\t{{{\r\n");
-	fwrite(msg, 1, len, fp1);
+	len = sprintf(msg,
+		"// Templates over 9 carriers for 4 phase values and 120 samples\n"
+		"// (only positive Phase values are in the table, sign reversal\n"
+		"//  is used to get the negative phase values).\n"
+		"// This reduces the table size from 8640 to 4320 integers\n\n"
+		"const short intPSK100bdCarTemplate[9][4][120] = {\n");
+	fwrite(msg, 1, len, fout);
 
 	for (i = 0; i <= 8; i++)		// across 9 tones
 	{
-		for (j = 0; j <= 3; j++)	// ( using only half the values and sign compliment for the opposit phases) 
+		for (j = 0; j <= 3; j++)	// ( using only half the values and sign compliment for the opposite phases) 
 		{
 			line = 0;
 
-			for (k = 0; k <= 119; k++) // for 120 samples (one 100 baud symbol, 200 baud modes will just use half of the data)
+			for (k = 0; k <= 119; k++) // for 120 samples (one 100 baud symbol)
 			{
 				if ((k - line) == 9)
 				{
 					// print 10 to line
-
-					len = sprintf(msg, "\t%d, %d, %d, %d, %d, %d, %d, %d, %d, %d,\n",
-					intPSK100bdCarTemplate[i][j][line],
-					intPSK100bdCarTemplate[i][j][line + 1],
-					intPSK100bdCarTemplate[i][j][line + 2],
-					intPSK100bdCarTemplate[i][j][line + 3],
-					intPSK100bdCarTemplate[i][j][line + 4],
-					intPSK100bdCarTemplate[i][j][line + 5],
-					intPSK100bdCarTemplate[i][j][line + 6],
-					intPSK100bdCarTemplate[i][j][line + 7],
-					intPSK100bdCarTemplate[i][j][line + 8],
-					intPSK100bdCarTemplate[i][j][line + 9]);
+					if (line == 0 && j == 0)
+						sprintf(prefix, "\t{{");
+					else if (line == 0)
+						sprintf(prefix, "\t{");
+					else
+						sprintf(prefix, "\t");
+					if (i + 1 == 9 && j + 1 == 4 && k + 1 == 120)
+						sprintf(suffix, "}}\n};\n\n");
+					else if (j + 1 == 4 && k + 1 == 120)
+						sprintf(suffix, "}},\n\n");
+					else if (k + 1 == 120)
+						sprintf(suffix, "},\n");
+					else
+						sprintf(suffix, ",\n");
+					len = sprintf(msg, "%s%d, %d, %d, %d, %d, %d, %d, %d, %d, %d%s",
+					prefix,
+					intNewPSK100bdCarTemplate[i][j][line],
+					intNewPSK100bdCarTemplate[i][j][line + 1],
+					intNewPSK100bdCarTemplate[i][j][line + 2],
+					intNewPSK100bdCarTemplate[i][j][line + 3],
+					intNewPSK100bdCarTemplate[i][j][line + 4],
+					intNewPSK100bdCarTemplate[i][j][line + 5],
+					intNewPSK100bdCarTemplate[i][j][line + 6],
+					intNewPSK100bdCarTemplate[i][j][line + 7],
+					intNewPSK100bdCarTemplate[i][j][line + 8],
+					intNewPSK100bdCarTemplate[i][j][line + 9],
+					suffix);
+					fwrite(msg, 1, len, fout);
 
 					line = k + 1;
-
-					if (k == 119)
-					{
-						len += sprintf(&msg[len-2], "},\r\n\t{");
-						len -=2;
-					}
-					fwrite(msg, 1, len, fp1);
 				}
 			}
-//			len = sprintf(msg, "\t}{\r\n");
-//			fwrite(msg, 1, len, fp1);
 		}
-		len = sprintf(msg, "\t}}{{\r\n");
-		fwrite(msg, 1, len, fp1);
 	}
-
-	len = sprintf(msg, "\t}}};\r\n");
-	fwrite(msg, 1, len, fp1);
-	fclose(fp1);
-	
 }
 
 
-#endif
+void CompareResults() {
+	int oldvmax;
+	int oldvmin;
+	int vmax;
+	int vmin;
+	int delta;
+	int dmax;
+	int dmin;
+	double oldvsum;
+	double vsum;
+	double oldvsquaredsum;
+	double vsquaredsum;
+	int iNum;
+	int jNum;
+	int kNum;
 
+	printf(
+		"\nComparison of existing to newly calculated results:\n"
+		"                                 Existing    New Values  Change\n"
+	);
 
+	printf("\n");
+	oldvmax = 0;
+	oldvmin = 0;
+	vmax = 0;
+	vmin = 0;
+	dmax = 0;
+	dmin = 0;
+	oldvsum = 0.0;
+	vsum = 0.0;
+	oldvsquaredsum = 0.0;
+	vsquaredsum = 0.0;
+	iNum = 120;
+	for (int i = 0; i < iNum; i++) {
+		oldvsum += int50BaudTwoToneLeaderTemplate[i];
+		vsum += intNew50BaudTwoToneLeaderTemplate[i];
+		oldvsquaredsum += pow(int50BaudTwoToneLeaderTemplate[i], 2);
+		vsquaredsum += pow(intNew50BaudTwoToneLeaderTemplate[i], 2);
+		if (int50BaudTwoToneLeaderTemplate[i] < oldvmin)
+			oldvmin = int50BaudTwoToneLeaderTemplate[i];
+		if (int50BaudTwoToneLeaderTemplate[i] > oldvmax)
+			oldvmax = intNew50BaudTwoToneLeaderTemplate[i];
+
+		if (intNew50BaudTwoToneLeaderTemplate[i] < vmin)
+			vmin = intNew50BaudTwoToneLeaderTemplate[i];
+		if (intNew50BaudTwoToneLeaderTemplate[i] > vmax)
+			vmax = intNew50BaudTwoToneLeaderTemplate[i];
+
+		delta = intNew50BaudTwoToneLeaderTemplate[i] -
+			int50BaudTwoToneLeaderTemplate[i];
+
+		if (delta < dmin)
+			dmin = delta;
+		if (delta > dmax)
+			dmax = delta;
+	}
+	printf(
+		"int50BaudTwoToneLeaderTemplate[] using %d values"
+		" (max single value change: %d %d)\n"
+		"  Maximum value:                 %-+10d  %-+10d  %-+10d\n"
+		"  Minimum value:                 %-+10d  %-+10d  %-+10d\n"
+		"  Mean value (ideally zero):     %-+10.2f  %-+10.2f  %-+10.2f\n"
+		"  RMS Power:                     %-10.2f  %-10.2f  %-10.2f\n",
+		iNum,
+		dmin, dmax,
+		oldvmax, vmax, vmax - oldvmax,
+		oldvmin, vmin, vmin - oldvmin,
+		oldvsum / iNum, vsum / iNum, vsum / iNum - oldvsum / iNum,
+		sqrt(oldvsquaredsum / iNum), sqrt(vsquaredsum / iNum),
+		sqrt(vsquaredsum / iNum) - sqrt(oldvsquaredsum / iNum)
+	);
+
+	printf("\n");
+	iNum = 4;
+	kNum = 240;
+	for (int i = 0; i < iNum; i++) {
+		oldvmax = 0;
+		oldvmin = 0;
+		vmax = 0;
+		vmin = 0;
+		dmax = 0;
+		dmin = 0;
+		oldvsum = 0.0;
+		vsum = 0.0;
+		oldvsquaredsum = 0.0;
+		vsquaredsum = 0.0;
+		for (int k = 0; k < kNum; k++) {
+			oldvsum += intFSK50bdCarTemplate[i][k];
+			vsum += intNewFSK50bdCarTemplate[i][k];
+			oldvsquaredsum += pow(intFSK50bdCarTemplate[i][k], 2);
+			vsquaredsum += pow(intNewFSK50bdCarTemplate[i][k], 2);
+			if (intFSK50bdCarTemplate[i][k] < oldvmin)
+				oldvmin = intFSK50bdCarTemplate[i][k];
+			if (intFSK50bdCarTemplate[i][k] > oldvmax)
+				oldvmax = intFSK50bdCarTemplate[i][k];
+
+			if (intNewFSK50bdCarTemplate[i][k] < vmin)
+				vmin = intNewFSK50bdCarTemplate[i][k];
+			if (intNewFSK50bdCarTemplate[i][k] > vmax)
+				vmax = intNewFSK50bdCarTemplate[i][k];
+
+			delta = intNewFSK50bdCarTemplate[i][k] -
+				intFSK50bdCarTemplate[i][k];
+
+			if (delta < dmin)
+				dmin = delta;
+			if (delta > dmax)
+				dmax = delta;
+		}
+		printf(
+			"intFSK50bdCarTemplate[%d][] using %d values"
+			" (max single value change: %d %d)\n"
+			"  Maximum value:                 %-+10d  %-+10d  %-+10d\n"
+			"  Minimum value:                 %-+10d  %-+10d  %-+10d\n"
+			"  Mean value (ideally zero):     %-+10.2f  %-+10.2f  %-+10.2f\n"
+			"  RMS Power:                     %-10.2f  %-10.2f  %-10.2f\n",
+			i, kNum,
+			dmin, dmax,
+			oldvmax, vmax, vmax - oldvmax,
+			oldvmin, vmin, vmin - oldvmin,
+			oldvsum / kNum, vsum / kNum, vsum / kNum - oldvsum / kNum,
+			sqrt(oldvsquaredsum / kNum), sqrt(vsquaredsum / kNum),
+			sqrt(vsquaredsum / kNum) - sqrt(oldvsquaredsum / kNum)
+		);
+	}
+
+	printf("\n");
+	iNum = 4;
+	kNum = 20;
+	for (int i = 0; i < iNum; i++) {
+		oldvmax = 0;
+		oldvmin = 0;
+		vmax = 0;
+		vmin = 0;
+		dmax = 0;
+		dmin = 0;
+		oldvsum = 0.0;
+		vsum = 0.0;
+		oldvsquaredsum = 0.0;
+		vsquaredsum = 0.0;
+		for (int k = 0; k < kNum; k++) {
+			oldvsum += intFSK600bdCarTemplate[i][k];
+			vsum += intNewFSK600bdCarTemplate[i][k];
+			oldvsquaredsum += pow(intFSK600bdCarTemplate[i][k], 2);
+			vsquaredsum += pow(intNewFSK600bdCarTemplate[i][k], 2);
+			if (intFSK600bdCarTemplate[i][k] < oldvmin)
+				oldvmin = intFSK600bdCarTemplate[i][k];
+			if (intFSK600bdCarTemplate[i][k] > oldvmax)
+				oldvmax = intFSK600bdCarTemplate[i][k];
+
+			if (intNewFSK600bdCarTemplate[i][k] < vmin)
+				vmin = intNewFSK600bdCarTemplate[i][k];
+			if (intNewFSK600bdCarTemplate[i][k] > vmax)
+				vmax = intNewFSK600bdCarTemplate[i][k];
+
+			delta = intNewFSK600bdCarTemplate[i][k] -
+				intFSK600bdCarTemplate[i][k];
+
+			if (delta < dmin)
+				dmin = delta;
+			if (delta > dmax)
+				dmax = delta;
+		}
+		printf(
+			"intFSK600bdCarTemplate[%d][] using %d values"
+			" (max single value change: %d %d)\n"
+			"  Maximum value:                 %-+10d  %-+10d  %-+10d\n"
+			"  Minimum value:                 %-+10d  %-+10d  %-+10d\n"
+			"  Mean value (ideally zero):     %-+10.2f  %-+10.2f  %-+10.2f\n"
+			"  RMS Power:                     %-10.2f  %-10.2f  %-10.2f\n",
+			i, kNum,
+			dmin, dmax,
+			oldvmax, vmax, vmax - oldvmax,
+			oldvmin, vmin, vmin - oldvmin,
+			oldvsum / kNum, vsum / kNum, vsum / kNum - oldvsum / kNum,
+			sqrt(oldvsquaredsum / kNum), sqrt(vsquaredsum / kNum),
+			sqrt(vsquaredsum / kNum) - sqrt(oldvsquaredsum / kNum)
+		);
+	}
+
+	printf("\n");
+	iNum = 4;
+	kNum = 120;
+	for (int i = 0; i < iNum; i++) {
+		oldvmax = 0;
+		oldvmin = 0;
+		vmax = 0;
+		vmin = 0;
+		dmax = 0;
+		dmin = 0;
+		oldvsum = 0.0;
+		vsum = 0.0;
+		oldvsquaredsum = 0.0;
+		vsquaredsum = 0.0;
+		for (int k = 0; k < kNum; k++) {
+			oldvsum += intFSK100bdCarTemplate[i][k];
+			vsum += intNewFSK100bdCarTemplate[i][k];
+			oldvsquaredsum += pow(intFSK100bdCarTemplate[i][k], 2);
+			vsquaredsum += pow(intNewFSK100bdCarTemplate[i][k], 2);
+			if (intFSK100bdCarTemplate[i][k] < oldvmin)
+				oldvmin = intFSK100bdCarTemplate[i][k];
+			if (intFSK100bdCarTemplate[i][k] > oldvmax)
+				oldvmax = intFSK100bdCarTemplate[i][k];
+
+			if (intNewFSK100bdCarTemplate[i][k] < vmin)
+				vmin = intNewFSK100bdCarTemplate[i][k];
+			if (intNewFSK100bdCarTemplate[i][k] > vmax)
+				vmax = intNewFSK100bdCarTemplate[i][k];
+
+			delta = intNewFSK100bdCarTemplate[i][k] -
+				intFSK100bdCarTemplate[i][k];
+
+			if (delta < dmin)
+				dmin = delta;
+			if (delta > dmax)
+				dmax = delta;
+		}
+		printf(
+			"intFSK100bdCarTemplate[%d][] using %d values"
+			" (max single value change: %d %d)\n"
+			"  Maximum value:                 %-+10d  %-+10d  %-+10d\n"
+			"  Minimum value:                 %-+10d  %-+10d  %-+10d\n"
+			"  Mean value (ideally zero):     %-+10.2f  %-+10.2f  %-+10.2f\n"
+			"  RMS Power:                     %-10.2f  %-10.2f  %-10.2f\n",
+			i, kNum,
+			dmin, dmax,
+			oldvmax, vmax, vmax - oldvmax,
+			oldvmin, vmin, vmin - oldvmin,
+			oldvsum / kNum, vsum / kNum, vsum / kNum - oldvsum / kNum,
+			sqrt(oldvsquaredsum / kNum), sqrt(vsquaredsum / kNum),
+			sqrt(vsquaredsum / kNum) - sqrt(oldvsquaredsum / kNum)
+		);
+	}
+
+	printf("\n");
+	iNum = 9;
+	jNum = 4;
+	kNum = 120;
+	for (int i = 0; i < iNum; i++) {
+		printf("\n");
+		for (int j = 0; j < jNum; j++) {
+			oldvmax = 0;
+			oldvmin = 0;
+			vmax = 0;
+			vmin = 0;
+			dmax = 0;
+			dmin = 0;
+			oldvsum = 0.0;
+			vsum = 0.0;
+			oldvsquaredsum = 0.0;
+			vsquaredsum = 0.0;
+			for (int k = 0; k < kNum; k++) {
+				oldvsum += intPSK100bdCarTemplate[i][j][k];
+				vsum += intNewPSK100bdCarTemplate[i][j][k];
+				oldvsquaredsum += pow(intPSK100bdCarTemplate[i][j][k], 2);
+				vsquaredsum += pow(intNewPSK100bdCarTemplate[i][j][k], 2);
+				if (intPSK100bdCarTemplate[i][j][k] < oldvmin)
+					oldvmin = intPSK100bdCarTemplate[i][j][k];
+				if (intPSK100bdCarTemplate[i][j][k] > oldvmax)
+					oldvmax = intPSK100bdCarTemplate[i][j][k];
+
+				if (intNewPSK100bdCarTemplate[i][j][k] < vmin)
+					vmin = intNewPSK100bdCarTemplate[i][j][k];
+				if (intNewPSK100bdCarTemplate[i][j][k] > vmax)
+					vmax = intNewPSK100bdCarTemplate[i][j][k];
+
+				delta = intNewPSK100bdCarTemplate[i][j][k] -
+					intPSK100bdCarTemplate[i][j][k];
+
+				if (delta < dmin)
+					dmin = delta;
+				if (delta > dmax)
+					dmax = delta;
+			}
+			printf(
+				"intPSK100bdCarTemplate[%d][%d][] using %d values"
+				" (max single value change: %d %d)\n"
+				"  Maximum value:                 %-+10d  %-+10d  %-+10d\n"
+				"  Minimum value:                 %-+10d  %-+10d  %-+10d\n"
+				"  Mean value (ideally zero):     %-+10.2f  %-+10.2f  %-+10.2f\n"
+				"  RMS Power:                     %-10.2f  %-10.2f  %-10.2f\n",
+				i, j, kNum,
+				dmin, dmax,
+				oldvmax, vmax, vmax - oldvmax,
+				oldvmin, vmin, vmin - oldvmin,
+				oldvsum / kNum, vsum / kNum, vsum / kNum - oldvsum / kNum,
+				sqrt(oldvsquaredsum / kNum), sqrt(vsquaredsum / kNum),
+				sqrt(vsquaredsum / kNum) - sqrt(oldvsquaredsum / kNum)
+			);
+		}
+	}
+}
+
+int main() {
+	char pathname[] = "newArdopSampleArrays.c";
+	fout = fopen(pathname, "wb");
+	printf(
+		"Writing new sample arrays to %s.\n"
+		"  To have ardopcf use these new values, replace the existing\n"
+		"  ardopSampleArrays.c with %s and recompile ardopcf.\n"
+		"  WARNING:\n"
+		"    Before replacing ardopSampleArrays.c with newly calculated\n"
+		"    values, printed comparison of Existing to New Values should\n"
+		"    be carefully inspected to ensure that no unintentional changes\n"
+		"    are being made.  If uncertain about these results, further\n"
+		"    evaluation of the new values should be done.\n",
+		pathname, pathname
+	);
+	Generate50BaudTwoToneLeaderTemplate();
+	GenerateFSKTemplates();
+	GeneratePSKTemplates();
+	fclose(fout);
+	CompareResults();
+}


### PR DESCRIPTION
ardopcf (and ardopc before it) uses precalculated waveform sample values from ardopSampleArrays.c as the basis for data sent to the soundcard to transmit.  CalcTemplates.c is intended to contain the source code that generated ardopSampleArrays.c.  However, CalcTemplates.c had not been maintained and was not fully functional.

This branch restores CalcTemplates.c so that it is now capable of producing newArdopSampleArrays.c containing data nearly identical to the existing ardopSampleArrays.c.  The format is close, but not exactly the same.  The data values are within +/- 2 (out of +/- 32k).  By writing to a different file, the results can be compared before deciding whether or not to replace ardopSampleArrays.c with newArdopSampleArrays.c.  Running CalcTemplates also prints some data comparing the new values to those found in ardopSamplesArrays.c.  This is intended to help the developers to be confident that no unintended changes are being made.

The resulting newArdopSampleArrays.c is intended to be a temporary file that is either used to replace ardopSampleArrays.c or is deleted.  It should not be included in the git repository.  Therefore .gitignore is updated to exclude both this file and CalcTemplates, the compiled executable file.  Instructions for building CalcTemplates with a single call to gcc is provided as a comment near the top of CalcTemplates.c.

Inspection of CalcTemplates.c allows the developers to see and understand the form of what is being transmitted much more easily than looking at the large arrays of numbers in ardopSampleArrays.c.