### PR TITLE
Bugfix for GH Issue #37 - correct invalid index limit in Filter75Hz().

### DIFF
--- a/ARDOPC/SoundInput.c
+++ b/ARDOPC/SoundInput.c
@@ -454,7 +454,7 @@ void Filter75Hz(short * intFilterOut, BOOL blnInitialise, int intSamplesToFilter
 
 	if (dblCoef[2] == 0)
 	{
-		for (i = 0; i <= 3; i++)
+		for (i = 0; i < 3; i++)
 		{
 			dblCoef[i] = 2 * dblR * cosf(2 * M_PI * (29 + i)/ intN);  // For Frequency = bin 29, 30, 31
 		}


### PR DESCRIPTION
Issue #37 suggests using ASAN and UBSAN to help identify bugs.  Initial use of those tools identified a bug, which was reported in that same issue.

The bug was an invalid index limit from the use of `for (i = 0; i <= 3; i++)` where it should have been `for (i = 0; i < 3; i++)`.  This commit fixes that error.  This should not change the behavior of ardopcf, except to avoid assignment to an invalid address.