### PR TITLE
Issue #66 fix: Reset last acked data frame type when in DISC protocol state

### DIFF
--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -276,6 +276,7 @@ void SetARDOPProtocolState(int value)
 		wg_send_issled(0, false);
 		wg_send_irsled(0, false);
 		wg_send_rcall(0, "");
+		bytLastACKedDataFrameType = 0;
 		break;
 
 	case FECRcv:


### PR DESCRIPTION
Should help with Issue #66 (for ardopcf)
Will not fix ardopcf connecting to a station that does not have the corrected logic, such as AROP_WinTNC (almost all current Winlink RMS stations)

Tested with two ardopcf stations running Pat, 50+ sessions with average of 5 data frames used per session, variable frame decoding conditions, ensuring that some frames are not decoded properly, increasing chance of this fringe control case.

I would have liked to test this in place of ARDOP_WinTNC for a more in-place fix.
