### PR TITLE
Bugfix asan

### DIFF
--- a/lib/ws_server/ws_server.c
+++ b/lib/ws_server/ws_server.c
@@ -202,7 +202,7 @@ static void sha1_block(unsigned char m[64], unsigned int h[5]) {
 	unsigned int k[4] = {0x5a827999, 0x6ed9eba1, 0x8f1bbcdc, 0xca62c1d6};
 	// prepare the message schedule per section 6.1.2 step 1
 	for (int i = 0; i < 16; i++)
-		w[i] = (m[i * 4]<<24) + m[ i * 4 + 1] * 65536
+		w[i] = ((unsigned int)(m[i * 4])<<24) + m[ i * 4 + 1] * 65536
 			+ m[i * 4 + 2]*256 + m[i * 4 + 3];
 	for (int i = 16; i < 80; i++) {
 		t = w[i-3] ^ w[i-8] ^ w[i-14] ^ w[i-16];

--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -700,7 +700,7 @@ void ardopmain()
 	// seed value.
 	struct timeval t1;
 	gettimeofday(&t1, NULL);
-	srand(t1.tv_usec * t1.tv_sec);
+	srand(t1.tv_usec + t1.tv_sec);
 
 	blnTimeoutTriggered = FALSE;
 	SetARDOPProtocolState(DISC);

--- a/src/common/HostInterface.c
+++ b/src/common/HostInterface.c
@@ -147,9 +147,14 @@ void ProcessCommandFromHost(char * strCMD)
 
 	strFault[0] = 0;
 
-	memcpy(cmdCopy, strCMD, sizeof(cmdCopy));  // save before we truncate or split it up
+	if (strlen(strCMD) >= sizeof(cmdCopy)) {
+		WriteDebugLog(LOGERROR,
+			"Host command too long to process (%d).  Ignoring. '%.40s...'",
+			strlen(strCMD), strCMD);
+		return;
+	}
 
-	strCMD[79] = 0;  // in case cmd handler gets garbage
+	memcpy(cmdCopy, strCMD, strlen(strCMD) + 1);  // save before we uppercase or split it up
 
 	_strupr(strCMD);
 

--- a/src/linux/ALSASound.c
+++ b/src/linux/ALSASound.c
@@ -1119,9 +1119,6 @@ int OpenSoundPlayback(char * PlaybackDevice, int m_sampleRate, int channels, cha
 		playhandle = NULL;
 	}
 
-	strcpy(SavedPlaybackDevice, PlaybackDevice);  // Saved so we can reopen in error recovery
-	SavedPlaybackRate = m_sampleRate;
-
 	strcpy(buf1, PlaybackDevice);
 
 	ptr = strchr(buf1, ' ');
@@ -1328,9 +1325,6 @@ int OpenSoundCapture(char * CaptureDevice, int m_sampleRate, char * ErrorMsg)
 		rechandle = NULL;
 	}
 
-	strcpy(SavedCaptureDevice, CaptureDevice);  // Saved so we can reopen in error recovery
-	SavedCaptureRate = m_sampleRate;
-
 	strcpy(buf1, CaptureDevice);
 
 	ptr = strchr(buf1, ' ');
@@ -1464,6 +1458,8 @@ int OpenSoundCard(char * CaptureDevice, char * PlaybackDevice, int c_sampleRate,
 	if (UseLeftTX == 0 || UseRightTX == 0)
 		Channels = 2;  // L or R implies stereo
 
+	strcpy(SavedPlaybackDevice, PlaybackDevice);  // Saved so we can reopen in error recovery
+	SavedPlaybackRate = p_sampleRate;
 	if (OpenSoundPlayback(PlaybackDevice, p_sampleRate, Channels, ErrorMsg))
 	{
 #ifdef SHARECAPTURE
@@ -1477,6 +1473,9 @@ int OpenSoundCard(char * CaptureDevice, char * PlaybackDevice, int c_sampleRate,
 		}
 #endif
 		Debugprintf("Opening Capture Device %s Rate %d", CaptureDevice, c_sampleRate);
+
+		strcpy(SavedCaptureDevice, CaptureDevice);  // Saved so we can reopen in error recovery
+		SavedCaptureRate = c_sampleRate;
 		return OpenSoundCapture(CaptureDevice, c_sampleRate, ErrorMsg);
 	}
 	else


### PR DESCRIPTION
Using ASAN and UBSAN as described in the now closed Issue #37, a few cases of bad memory use and undefined behavior were identified.  Each of the commits in this pull request fixes one of those issues.  

One of these was detected by running ardopcf for an extended period of time (with ASAN and UBSAN) with a radio tuned to hear ongoing FT8 signals.  As discovered earlier, these signals are sometimes mistaken for bad ardop frames.  Issue #54 describes ardopcf crashing under conditions of trying to demodulate/decode bad data.  I believe that the bug found by this testing was what caused the crash reported in that Issue.  This bug was fixed by ensuring that some extra received sound samples were always available before attempting to demodulate the frame data.  Without this, and with random or very noisy data, an invalid memmove() function was sometimes attempted.