### PR TITLE
Followup to changes to (De)CompressCallsign().

### DIFF
--- a/src/common/ARDOPC.h
+++ b/src/common/ARDOPC.h
@@ -134,6 +134,7 @@ int * intBaud, int * intDataLen, int * intRSLen, UCHAR * bytQualThres, char * st
 void ClearDataToSend();
 int EncodeFSKData(UCHAR bytFrameType, UCHAR * bytDataToSend, int Length, unsigned char * bytEncodedBytes);
 int EncodePSKData(UCHAR bytFrameType, UCHAR * bytDataToSend, int Length, unsigned char * bytEncodedBytes);
+int EncodePing(char * strMyCallsign, char * strTargetCallsign, UCHAR * bytReturn);
 int Encode4FSKIDFrame(char * Callsign, char * Square, unsigned char * bytreturn);
 int EncodeDATAACK(int intQuality, UCHAR bytSessionID, UCHAR * bytreturn);
 int EncodeDATANAK(int intQuality , UCHAR bytSessionID, UCHAR * bytreturn);
@@ -189,6 +190,8 @@ int GetNextFrameData(int * intUpDn, UCHAR * bytFrameTypeToSend, UCHAR * strMod, 
 void SendData();
 int ComputeInterFrameInterval(int intRequestedIntervalMS);
 int Encode4FSKControl(UCHAR bytFrameType, UCHAR bytSessionID, UCHAR * bytreturn);
+int EncodeConACKwTiming(UCHAR bytFrameType, int intRcvdLeaderLenMs, UCHAR bytSessionID, UCHAR * bytreturn);
+int EncodePingAck(int bytFrameType, int intSN, int intQuality, UCHAR * bytreturn);
 VOID WriteExceptionLog(const char * format, ...);
 void SaveQueueOnBreak();
 VOID Statsprintf(const char * format, ...);
@@ -250,8 +253,6 @@ extern int WaterfallActive;
 extern int SpectrumActive;
 extern unsigned int PKTLEDTimer;
 
-extern char stcLastPingstrSender[10];
-extern char stcLastPingstrTarget[10];
 extern int stcLastPingintRcvdSN;
 extern int stcLastPingintQuality;
 extern time_t stcLastPingdttTimeReceived;
@@ -393,9 +394,12 @@ extern const short intFSK50bdCarTemplate[4][240];  // Template for 4FSK carriers
 extern const short intFSK100bdCarTemplate[20][120];  // Template for 4FSK carriers spaced at 100 Hz, 100 baud
 extern const short intFSK600bdCarTemplate[4][20];  // Template for 4FSK carriers spaced at 600 Hz, 600 baud  (used for FM only)
 
+#define CALL_BUF_SIZE 10  // size of buffer for callsign strings
+#define AUXCALLS_ALEN 10  // length of AuxCalls array
+#define COMP_SIZE 6  // size of compressed callsign or gridsquare
 // Config Params
 extern char GridSquare[9];
-extern char Callsign[10];
+extern char Callsign[CALL_BUF_SIZE];
 extern BOOL wantCWID;
 extern BOOL CWOnOff;
 extern int LeaderLength;
@@ -497,7 +501,7 @@ extern BOOL AccumulateStats;
 extern unsigned char bytEncodedBytes[1800];
 extern int EncLen;
 
-extern char AuxCalls[10][10];
+extern char AuxCalls[AUXCALLS_ALEN][CALL_BUF_SIZE];
 extern int AuxCallsLength;
 
 extern int bytValidFrameTypesLength;
@@ -589,6 +593,6 @@ extern int initMode;  // 0 - 4PSK 1 - 8PSK 2 = 16QAM
 
 // Has to follow enum defs
 
-BOOL EncodeARQConRequest(char * strMyCallsign, char * strTargetCallsign, enum _ARQBandwidth ARQBandwidth, UCHAR * bytReturn);
+int EncodeARQConRequest(char * strMyCallsign, char * strTargetCallsign, enum _ARQBandwidth ARQBandwidth, UCHAR * bytReturn);
 
 #endif

--- a/src/common/HostInterface.c
+++ b/src/common/HostInterface.c
@@ -23,7 +23,7 @@ extern BOOL NeedID;  // SENDID Command Flag
 extern BOOL NeedConReq;  // ARQCALL Command Flag
 extern BOOL NeedPing;
 extern BOOL PingCount;
-extern char ConnectToCall[16];
+extern char ConnectToCall[CALL_BUF_SIZE];
 extern enum _ARQBandwidth CallBandwidth;
 extern int extraDelay ;  // Used for long delay paths eg Satellite
 extern BOOL WG_DevMode;
@@ -816,7 +816,7 @@ void ProcessCommandFromHost(char * strCMD)
 
 		AuxCallsLength = 0;
 
-		while (ptr && AuxCallsLength < 10)
+		while (ptr && AuxCallsLength < AUXCALLS_ALEN)
 		{
 			if (CheckValidCallsignSyntax(ptr))
 				strcpy(AuxCalls[AuxCallsLength++], ptr);

--- a/src/common/SoundInput.c
+++ b/src/common/SoundInput.c
@@ -211,7 +211,7 @@ extern UCHAR bytSessionID;
 int dttLastGoodFrameTypeDecod;
 int dttStartRmtLeaderMeasure;
 
-char lastGoodID[11] = "";
+char lastGoodID[CALL_BUF_SIZE] = "";
 
 int GotBitSyncTicks;
 
@@ -2686,9 +2686,9 @@ extern int intBW;
 
 BOOL Decode4FSKConReq()
 {
-	UCHAR strCaller[32];
-	UCHAR strTarget [32];
-	UCHAR bytCall[6];
+	UCHAR strCaller[CALL_BUF_SIZE];
+	UCHAR strTarget[CALL_BUF_SIZE];
+	UCHAR bytCall[COMP_SIZE];
 	BOOL FrameOK;
 
 	// Modified May 24, 2015 to use RS encoding vs CRC (similar to ID Frame)
@@ -2715,9 +2715,9 @@ BOOL Decode4FSKConReq()
 		WriteDebugLog(LOGDEBUG, "CONREQ Still bad after RS");
 		FrameOK = FALSE;
 	}
-	memcpy(bytCall, bytFrameData1, 6);
+	memcpy(bytCall, bytFrameData1, COMP_SIZE);
 	DeCompressCallsign(bytCall, strCaller, sizeof(strCaller));
-	memcpy(bytCall, &bytFrameData1[6], 6);
+	memcpy(bytCall, &bytFrameData1[COMP_SIZE], COMP_SIZE);
 	DeCompressCallsign(bytCall, strTarget, sizeof(strTarget));
 
 //	printtick(strCaller);
@@ -2738,7 +2738,7 @@ BOOL Decode4FSKConReq()
 		intBW = 2000;
 
 	if (FrameOK)
-		memcpy(lastGoodID, strCaller, 10);
+		memcpy(lastGoodID, strCaller, CALL_BUF_SIZE);
 	else
 		SendCommandToHost("CANCELPENDING");
 
@@ -2799,9 +2799,9 @@ int Compute4FSKSN()
 
 BOOL Decode4FSKPing()
 {
-	UCHAR strCaller[10];
-	UCHAR strTarget [10];
-	UCHAR bytCall[6];
+	UCHAR strCaller[CALL_BUF_SIZE];
+	UCHAR strTarget[CALL_BUF_SIZE];
+	UCHAR bytCall[COMP_SIZE];
 	BOOL FrameOK;
 
 	int NErrors = rs_correct(bytFrameData1, 16, 4, true, false);
@@ -2827,9 +2827,9 @@ BOOL Decode4FSKPing()
 		FrameOK = FALSE;
 	}
 
-	memcpy(bytCall, bytFrameData1, 6);
+	memcpy(bytCall, bytFrameData1, COMP_SIZE);
 	DeCompressCallsign(bytCall, strCaller, sizeof(strCaller));
-	memcpy(bytCall, &bytFrameData1[6], 6);
+	memcpy(bytCall, &bytFrameData1[COMP_SIZE], COMP_SIZE);
 	DeCompressCallsign(bytCall, strTarget, sizeof(strTarget));
 
 //	printtick(strCaller);
@@ -2859,8 +2859,6 @@ BOOL Decode4FSKPing()
 		WriteDebugLog(LOGDEBUG, "[DemodDecode4FSKPing] PING %s>%s S:N=%d Q=%d", strCaller, strTarget, intSNdB, intLastRcvdFrameQuality);
 
 		stcLastPingdttTimeReceived = time(NULL);
-		memcpy(stcLastPingstrSender, strCaller, 10);
-		memcpy(stcLastPingstrTarget, strTarget, 10);
 		stcLastPingintRcvdSN = intSNdB;
 		stcLastPingintQuality = intLastRcvdFrameQuality;
 
@@ -2949,7 +2947,7 @@ BOOL Decode4FSKPingACK(UCHAR bytFrameType, int * intSNdB, int * intQuality)
 
 BOOL Decode4FSKID(UCHAR bytFrameType, char * strCallID, size_t strCallIDLen, char * strGridSquare)
 {
-	UCHAR bytCall[10];
+	UCHAR bytCall[COMP_SIZE];
 	UCHAR temp[20];
 	BOOL FrameOK;
 	unsigned char * p = bytFrameData1;
@@ -2981,9 +2979,9 @@ BOOL Decode4FSKID(UCHAR bytFrameType, char * strCallID, size_t strCallIDLen, cha
 		FrameOK = FALSE;
 	}
 
-	memcpy(bytCall, bytFrameData1, 6);
+	memcpy(bytCall, bytFrameData1, COMP_SIZE);
 	DeCompressCallsign(bytCall, strCallID, strCallIDLen);
-	memcpy(bytCall, &bytFrameData1[6], 6);
+	memcpy(bytCall, &bytFrameData1[COMP_SIZE], COMP_SIZE);
 	DeCompressGridSquare(bytCall, temp);
 
 	if (strlen(temp) > 5)
@@ -3001,7 +2999,7 @@ BOOL Decode4FSKID(UCHAR bytFrameType, char * strCallID, size_t strCallIDLen, cha
 	}
 
 	if (FrameOK)
-		memcpy(lastGoodID, strCallID, 10);
+		memcpy(lastGoodID, strCallID, CALL_BUF_SIZE);
 
 	return FrameOK;
 }
@@ -3181,9 +3179,7 @@ BOOL DecodeACKNAK(int intFrameType, int *  intQuality)
 BOOL DecodeFrame(int xxx, UCHAR * bytData)
 {
 	BOOL blnDecodeOK = FALSE;
-	char strCallerCallsign[10] = "";
-	char strTargetCallsign[10] = "";
-	char strIDCallSign[11] = "";
+	char strIDCallSign[CALL_BUF_SIZE] = "";
 	char strGridSQ[20] = "";
 	int intTiming;
 	int intRcvdQuality;

--- a/src/common/ardopcommon.h
+++ b/src/common/ardopcommon.h
@@ -1,4 +1,4 @@
-
+#include "common/ARDOPC.h"
 
 #ifndef ARDOPCOMMONDEFINED
 #define ARDOPCOMMONDEFINED
@@ -251,8 +251,6 @@ extern int WaterfallActive;
 extern int SpectrumActive;
 extern unsigned int PKTLEDTimer;
 
-extern char stcLastPingstrSender[10];
-extern char stcLastPingstrTarget[10];
 extern int stcLastPingintRcvdSN;
 extern int stcLastPingintQuality;
 extern time_t stcLastPingdttTimeReceived;
@@ -331,7 +329,7 @@ extern struct SEM Semaphore;
 
 // Config Params
 extern char GridSquare[9];
-extern char Callsign[10];
+extern char Callsign[CALL_BUF_SIZE];
 extern BOOL wantCWID;
 extern BOOL CWOnOff;
 extern int LeaderLength;
@@ -432,7 +430,7 @@ extern BOOL AccumulateStats;
 
 extern int EncLen;
 
-extern char AuxCalls[10][10];
+extern char AuxCalls[AUXCALLS_ALEN][CALL_BUF_SIZE];
 extern int AuxCallsLength;
 
 extern int bytValidFrameTypesLength;


### PR DESCRIPTION
PR #50 introduced some tests and changes to CompressCallsign() and DeCompressCallsign.  This extends those changes.  

Among other things, it writes debug log messages when invalid callsign values are encountered, and it defines `CALL_BUF_SIZE` and `COMP_SIZE` that are used to set the length of buffers used to hold callsign string values and compressed byte arrays respectively.