### PR TITLE
linux: signal handler safety

### DIFF
--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -49,6 +49,7 @@ void SerialHostPoll();
 void TCPHostPoll();
 BOOL MainPoll();
 void PlatformSleep();
+const char* PlatformSignalAbbreviation(int signal);
 BOOL BusyDetect2(float * dblMag, int intStart, int intStop);
 BOOL IsPingToMe(char * strCallsign);
 
@@ -208,6 +209,7 @@ int intRepeatCnt;
 extern SOCKET TCPControlSock, TCPDataSock;
 
 BOOL blnClosing = FALSE;
+int closedByPosixSignal = 0;
 BOOL blnCodecStarted = FALSE;
 
 unsigned int dttNextPlay = 0;
@@ -791,6 +793,14 @@ void ardopmain()
 			MainPoll();
 		}
 		PlatformSleep(10);
+	}
+
+	if (closedByPosixSignal) {
+		WriteDebugLog(
+			LOGINFO,
+			"Terminating on signal: %s",
+			PlatformSignalAbbreviation(closedByPosixSignal)
+		);
 	}
 
 	closesocket(TCPControlSock);

--- a/src/common/ardopcommon.h
+++ b/src/common/ardopcommon.h
@@ -405,6 +405,7 @@ extern BOOL SoundIsPlaying;
 extern int blnLastPTT;
 extern BOOL blnAbort;
 extern BOOL blnClosing;
+extern int closedByPosixSignal;
 extern BOOL blnCodecStarted;
 extern BOOL blnInitializing;
 extern BOOL blnARQDisconnect;

--- a/src/windows/Waveout.c
+++ b/src/windows/Waveout.c
@@ -1159,6 +1159,11 @@ void PlatformSleep(int mS)
 	}
 }
 
+const char* PlatformSignalAbbreviation(int signal) {
+	(void)signal;
+	return "Unused";
+}
+
 void DrawTXMode(const char * Mode)
 {
 	char Msg[80];


### PR DESCRIPTION
On Linux, the signal handlers call `printf()`. printf  is not [async-signal-safe](https://man7.org/linux/man-pages/man7/signal-safety.7.html) and must not be used in signal handlers.

Instead of directly printing, we record the signal ID that caused termination and print it later. Unfortunately, `strsignal()` is not particularly safe, and `sigabbrev_np()` is not portable. We instead write our own implementation, `PlatformSignalAbbreviation()`.

This fixes UB that can occur from a user interrupt like `^C`.

[1]: https://man7.org/linux/man-pages/man7/signal-safety.7.html