### PR TITLE
Expand debug logging at the LOGDEBUGPLUS level

### DIFF
--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -30,6 +30,7 @@ int wg_send_state(int cnum);
 int wg_send_rcall(int cnum, char *call);
 int wg_send_irsled(int cnum, bool isOn);
 int wg_send_issled(int cnum, bool isOn);
+unsigned char *utf8_check(unsigned char *s, size_t slen);
 
 int intLastFrameIDToHost = 0;
 int	intLastFailedFrameID = 0;
@@ -888,6 +889,18 @@ void SendData()
 			dttTimeoutTrip = Now;
 			blnEnbARQRpt = TRUE;
 			ARQState = ISSData;  // Should not be necessary
+
+
+			char Msg[3000] = "";
+
+			snprintf(Msg, sizeof(Msg), "[Encoding Data to TX] %d bytes as hex values: ", Len);
+			for (int i = 0; i < Len; i++)
+				snprintf(Msg + strlen(Msg), sizeof(Msg) - strlen(Msg) - 1, "%02X ", bytDataToSend[i]);
+			WriteDebugLog(LOGDEBUGPLUS, "%s", Msg);
+
+			if (utf8_check(bytDataToSend, Len) == NULL)
+				WriteDebugLog(LOGDEBUGPLUS, "[Encoding Data to TX] %d bytes as utf8 text: '%.*s'", Len, Len, bytDataToSend);
+
 
 			if (strcmp(strMod, "4FSK") == 0)
 			{

--- a/src/common/HostInterface.c
+++ b/src/common/HostInterface.c
@@ -79,6 +79,16 @@ extern UCHAR bytSessionID;
 
 void AddDataToDataToSend(UCHAR * bytNewData, int Len)
 {
+	char Msg[3000] = "";
+
+	snprintf(Msg, sizeof(Msg), "[bytNewData: Add to TX queue] %d bytes as hex values: ", Len);
+	for (int i = 0; i < Len; i++)
+		snprintf(Msg + strlen(Msg), sizeof(Msg) - strlen(Msg) - 1, "%02X ", bytNewData[i]);
+	WriteDebugLog(LOGDEBUGPLUS, "%s", Msg);
+
+	if (utf8_check(bytNewData, Len) == NULL)
+		WriteDebugLog(LOGDEBUGPLUS, "[bytNewData: Add to TX queue] %d bytes as utf8 text: '%.*s'", Len, Len, bytNewData);
+
 	char HostCmd[32];
 
 	if (Len == 0)
@@ -1422,6 +1432,16 @@ void SendReplyToHost(char * strText)
 
 void AddTagToDataAndSendToHost(UCHAR * bytData, char * strTag, int Len)
 {
+	char Msg[3000] = "";
+
+	snprintf(Msg, sizeof(Msg), "[RX Data: Send To Host with TAG=%s] %d bytes as hex values: ", strTag, Len);
+	for (int i = 0; i < Len; i++)
+		snprintf(Msg + strlen(Msg), sizeof(Msg) - strlen(Msg) - 1, "%02X ", bytData[i]);
+	WriteDebugLog(LOGDEBUGPLUS, "%s", Msg);
+
+	if (utf8_check(bytData, Len) == NULL)
+		WriteDebugLog(LOGDEBUGPLUS, "[RX Data: Send To Host with TAG=%s] %d bytes as utf8 text: '%.*s'", strTag, Len, Len, bytData);
+
 	TCPAddTagToDataAndSendToHost(bytData, strTag, Len);
 	if (WG_DevMode) {
 		if (utf8_check(bytData, Len) == NULL)

--- a/src/common/SoundInput.c
+++ b/src/common/SoundInput.c
@@ -3459,6 +3459,19 @@ BOOL DecodeFrame(int xxx, UCHAR * bytData)
 	{
 		WriteDebugLog(LOGINFO, "[DecodeFrame] Frame: %s Decode PASS,  Quality= %d,  RS fixed %d (of %d max).", Name(intFrameType),  intLastRcvdFrameQuality, totalRSErrors, (intRSLen / 2) * intNumCar);
 		wg_send_quality(0, intLastRcvdFrameQuality, totalRSErrors, (intRSLen / 2) * intNumCar);
+
+		if (frameLen > 0) {
+			char Msg[3000] = "";
+
+			snprintf(Msg, sizeof(Msg), "[Decoded bytData] %d bytes as hex values: ", frameLen);
+			for (int i = 0; i < frameLen; i++)
+				snprintf(Msg + strlen(Msg), sizeof(Msg) - strlen(Msg) - 1, "%02X ", bytData[i]);
+			WriteDebugLog(LOGDEBUGPLUS, "%s", Msg);
+
+			if (utf8_check(bytData, frameLen) == NULL)
+				WriteDebugLog(LOGDEBUGPLUS, "[Decoded bytData] %d bytes as utf8 text: '%.*s'", frameLen, frameLen, bytData);
+		}
+
 #ifdef PLOTCONSTELLATION
 		if (intFrameType == IDFRAME || (intFrameType >= ConReqmin && intFrameType <= ConReqmax))
 			DrawDecode(lastGoodID);  // ID or CONREQ

--- a/src/linux/ALSASound.c
+++ b/src/linux/ALSASound.c
@@ -2492,6 +2492,17 @@ UCHAR Pixels[4096];
 UCHAR * pixelPointer = Pixels;
 
 
+// This data may be copied and pasted from the debug log file into the
+// "Host Command" input box in the WebGui in developer mode to reproduce
+// the constellation plot.
+void LogConstellation() {
+	char Msg[10000] = "CPLOT ";
+	for (int i = 0; i < pixelPointer - Pixels; i++)
+		snprintf(Msg + strlen(Msg), sizeof(Msg) - strlen(Msg), "%02X", Pixels[i]);
+	WriteDebugLog(LOGDEBUGPLUS, "%s", Msg);
+}
+
+
 void mySetPixel(unsigned char x, unsigned char y, unsigned int Colour)
 {
 	// Used on Windows for constellation. Save points and send to GUI at end
@@ -2516,6 +2527,7 @@ void DrawAxes(int Qual, char * Mode)
 	UCHAR Msg[80];
 	SendtoGUI('C', Pixels, pixelPointer - Pixels);
 	wg_send_pixels(0, Pixels, pixelPointer - Pixels);
+	LogConstellation();
 	pixelPointer = Pixels;
 
 	sprintf(Msg, "%s Quality: %d", Mode, Qual);

--- a/src/windows/Waveout.c
+++ b/src/windows/Waveout.c
@@ -1420,6 +1420,17 @@ UCHAR Pixels[16384];
 UCHAR * pixelPointer = Pixels;
 
 
+// This data may be copied and pasted from the debug log file into the
+// "Host Command" input box in the WebGui in developer mode to reproduce
+// the constellation plot.
+void LogConstellation() {
+	char Msg[10000] = "CPLOT ";
+	for (int i = 0; i < pixelPointer - Pixels; i++)
+		snprintf(Msg + strlen(Msg), sizeof(Msg) - strlen(Msg), "%02X", Pixels[i]);
+	WriteDebugLog(LOGDEBUGPLUS, "%s", Msg);
+}
+
+
 void mySetPixel(unsigned char x, unsigned char y, unsigned int Colour)
 {
 	// Used on Windows for constellation. Save points and send to GUI at end
@@ -1448,6 +1459,7 @@ void DrawAxes(int Qual, char * Mode)
 	UCHAR Msg[80];
 	SendtoGUI('C', Pixels, pixelPointer - Pixels);
 	wg_send_pixels(0, Pixels, pixelPointer - Pixels);
+	LogConstellation();
 	pixelPointer = Pixels;
 
 	sprintf(Msg, "%s Quality: %d", Mode, Qual);

--- a/test/python/README.md
+++ b/test/python/README.md
@@ -12,4 +12,6 @@ Running these tests with ardopcf which has been compiled with ASAN/UBSAN may be 
 
 Each file whose filename has the form `test_*.py` is a python script that will perform one or more tests.  On any computer where `python` is installed, running `python test_wav_io.py` from within the `test/python` directory should run the tests, where `test_wav_io.py` is the test file to be run.  On Linux machines where `/usr/bin/python` exists and `test_wav_io.py` is set to be an executable file, it should also be possible to simply type './test_wav_io.py' in the `test/python` directory.  These test scripts require that the ardopcf executable be available in the root directory of the repository.
 
+Some test scripts may include `--verbose` and `-v` options.  In those cases `-v 0` will reduce the amount of data printed, `-v 1` will have no effect because this is the default level, `-v 2` (which is also equivalent to `-v`) and possibly `-v 3` will increase the amount of data printed.
+
 These test scripts may write quite a bit of text to the console while running, but will normally print a more compact summary of the results at the end.

--- a/webgui/webgui.js
+++ b/webgui/webgui.js
@@ -921,7 +921,16 @@ window.addEventListener("load", function(evt) {
 		// User has pressed Enter.  Send the command, update command histroy.
 		var text = evt.target.value;
 		if(text.length > 0) {
-			send_msg(encoder.encode("H~" + text), 2 + text.length);
+			// text is normally intended to be sent to ardopcf.  However,
+			// this interface may also be used to plot constellation data
+			// pasted into the input box as a hex string.  Such data must
+			// be prefixed with "CPLOT ".  Data of this format may be copied
+			// from the debug log.
+			if (text.indexOf("CPLOT ") == 0) {
+				drawConstellation(fromHexString(text.slice(6)));
+			} else {
+				send_msg(encoder.encode("H~" + text), 2 + text.length);
+			}
 		}
 		cmdhistory.push(text);
 		if (cmdhistory.length > cmdhistory_limit)


### PR DESCRIPTION
This writes additional diagnostic data to the debug log at the LOGDEBUGPLUS log level.  Values written include data sent and received from host programs, raw bit and character error rates for received data frames, data used by Webgui to create constellation plots, received data before and after RS correction.

The test_wav_io.py python test script is enhanced to optionally display bit an character error rates.

With the Webgui in developer mode, if constellation data from the debug log is pasted into the input box, the corresponding constellation plot is displayed.