### PR TITLE
Webgui minor enhancements and Bugfix to send IDFrame after RX of END

### DIFF
--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -2142,7 +2142,7 @@ void CheckTimers()
 			WriteDebugLog(LOGERROR, "ERROR: In CheckTimers() sending IDFrame before DIC Invalid EncLen (%d).", EncLen);
 			return;
 		}
-		Mod4FSKDataAndPlay(DISCFRAME, &bytEncodedBytes[0], EncLen, 0);  // only returns when all sent
+		Mod4FSKDataAndPlay(IDFRAME, &bytEncodedBytes[0], EncLen, 0);  // only returns when all sent
 		dttLastFECIDSent = Now;
 
 		if (AccumulateStats)
@@ -2537,7 +2537,7 @@ void SendPING(char * strMycall, char * strTargetCall, int intRpt)
 	intFrameRepeatInterval = 2000;  // ms Finn reported 7/4/2015 that 1600 was too short ...need further evaluation but temporarily moved to 2000 ms
 	blnEnbARQRpt = TRUE;
 
-	Mod4FSKDataAndPlay(bytEncodedBytes[0], &bytEncodedBytes[0], EncLen, LeaderLength);  // only returns when all sent
+	Mod4FSKDataAndPlay(PING, &bytEncodedBytes[0], EncLen, LeaderLength);  // only returns when all sent
 
 	blnAbort = False;
 	dttTimeoutTrip = Now;

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -1525,9 +1525,9 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				ClearDataToSend();
 
 				SetARDOPProtocolState(DISC);
-				InitializeConnection();
-				blnEnbARQRpt = FALSE;
 
+				// Send IDFrame must be done before InitializeConnection(),
+				// because it resets strLocalCallsign to an empty string.
 				if (CheckValidCallsignSyntax(strLocalCallsign))
 				{
 					dttLastFECIDSent = Now;
@@ -1537,6 +1537,9 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 					}
 					Mod4FSKDataAndPlay(IDFRAME, &bytEncodedBytes[0], EncLen, 0);  // only returns when all sent
 				}
+
+				InitializeConnection();
+				blnEnbARQRpt = FALSE;
 				return;
 			}
 

--- a/src/common/Webgui.c
+++ b/src/common/Webgui.c
@@ -472,6 +472,8 @@ int wg_send_mycall(int cnum, char *call) {
 	return wg_send_msg(cnum, msg, strlen(msg));
 }
 
+// For some frame types (ACK, NAK, PingAck)), the `frame` string
+// may include a small amount of data that was encoded in that frame.
 int wg_send_txframet(int cnum, const char *frame) {
 	char msg[64];
 	if (strlen(frame) > sizeof(msg) - 3) {

--- a/src/common/Webgui.c
+++ b/src/common/Webgui.c
@@ -482,6 +482,11 @@ int wg_send_txframet(int cnum, const char *frame) {
 	return wg_send_msg(cnum, msg, strlen(msg));
 }
 
+// `state` argument indicates whether frame is still being received (0),
+// has been successfully received (1) or failure to successfully receive
+// has occured (2).
+// For some frame types (ACK, NAK, PingAck, IDFrame, etc.)), the `frame` string
+// may include a small amount of data that was encoded in that frame.
 int wg_send_rxframet(int cnum, unsigned char state, const char *frame) {
 	char msg[64];
 	unsigned char st[3] = {'P', 'O', 'F'};

--- a/webgui/webgui.html
+++ b/webgui/webgui.html
@@ -226,6 +226,18 @@
 			background is used when sending a DataNAK frame telling the other station that you
 			were unable to decode some received data.
 			</p><p>
+			Received DataACK and DataNAK frames include a value indicating the quality of your
+			sent frame as recieved by the other station.  This quality is shown in the <b>RX
+			Frame Type</b> field along with the Frame Type.
+			</p><p>
+			In ARQ Protocol Mode, if a station does not receive a DataACK in response to
+			sending a data frame, it will re-send that frame.  When a repeated data frame
+			is received, the <b>RX Frame Type</b> field will show '(REPEAT)' after the frame
+			type.  If this occurs after you send a DataACK frame, it probably means that
+			the other station did not receive that DataACK.  This is only shown in ARQ
+			Protocol Mode, and only for data frames (not for control frames like IDLE or
+			BREAK).
+			</p><p>
 			The <b>'TX DriveLevel'</b> slider linearly scales the amplitude of the audio sent to
 			your radio by ardopcf.  This, along with your radio's settings and the 'speaker'
 			settings for your computer's soundcard, influences the strength and quality of

--- a/webgui/webgui.js
+++ b/webgui/webgui.js
@@ -351,6 +351,7 @@ window.addEventListener("load", function(evt) {
 	let clearrxtimer = null;
 	let rcvoverflowtimer = null;
 	let rcvunderflowtimer = null;
+	let lastRXtype = "";
 	WebSocketClient.onOpen = function() {
 		// Connection to ardopcf established.
 		console.log("WS connection to ardopcf opened.  Notify ardopcf.");
@@ -559,6 +560,14 @@ window.addEventListener("load", function(evt) {
 					// RX Frame type
 					let rxstatus = decodestr(rdata, 1);
 					let rxfrtype = decodestr(rdata, -1);
+					if (
+						document.getElementById("protocolmode").innerHTML == "ARQ"
+						&& (rxfrtype.endsWith(".E")
+							|| rxfrtype.endsWith(".O")
+						) && rxfrtype == lastRXtype
+					) {
+						rxfrtype += " (REPEAT)"
+					}
 					let rxe = document.getElementById("rxtype");
 					rxe.classList.remove("rxstate_pending");
 					rxe.classList.remove("rxstate_ok");
@@ -578,6 +587,7 @@ window.addEventListener("load", function(evt) {
 						// by a rxstate_ok or rxstate_fail, so don't
 						// set a timer to clear it.
 						// Don't write pending rx to txtlog
+						// Don't update lastRXtype for pending
 						break;
 					case "O":
 						rxe.classList.add("rxstate_ok");
@@ -588,6 +598,8 @@ window.addEventListener("load", function(evt) {
 						}, 5000);  // clear after 5 seconds
 						txtlog.value += "RX: " + rxfrtype + " PASS\n";
 						txtlog.scrollTo(0, txtlog.scrollHeight);
+						if (!rxfrtype.endsWith(" (REPEAT)"))
+							lastRXtype = rxfrtype;
 						break;
 					case "F":
 						rxe.classList.add("rxstate_fail");
@@ -598,6 +610,8 @@ window.addEventListener("load", function(evt) {
 						}, 5000);  // clear after 5 seconds
 						txtlog.value += "RX: " + rxfrtype + " FAIL\n";
 						txtlog.scrollTo(0, txtlog.scrollHeight);
+						if (!rxfrtype.endsWith(" (REPEAT)"))
+							lastRXtype = rxfrtype;
 						break;
 					}
 					rxe.innerHTML = rxfrtype;

--- a/webgui/webgui.js
+++ b/webgui/webgui.js
@@ -670,6 +670,10 @@ window.addEventListener("load", function(evt) {
 					// txtlog.value += "PTT = true\n";
 					// txtlog.scrollTo(0, txtlog.scrollHeight);
 					document.getElementById("ptt").classList.remove("hidden");
+					// Reset spectrum and add a white line to the waterfall
+					// to mark a period of transmit.
+					drawSpectrum(null);
+					addWaterfallLine(2);
 					break;
 				case "p": {
 					// PTT false
@@ -979,6 +983,8 @@ window.addEventListener("load", function(evt) {
 	const drawSpectrum = (values) => {
 		spCtx.fillStyle = "#000";
 		spCtx.fillRect(0, 0, plotscale * spWidth, plotscale * spHeight);
+		if (!(values instanceof Uint8Array))
+			return;
 		spCtx.beginPath();
 		spCtx.moveTo(0, plotscale * spHeight);
 		for(var i=0; i<values.length; i++) {  // 2 frequency values per i
@@ -1027,6 +1033,22 @@ window.addEventListener("load", function(evt) {
 			plotscale,
 			plotscale * wfWidth,
 			plotscale * wfHeight);
+		if (!(values instanceof Uint8Array)) {
+			// Add blank white lines
+			let colorValues = new Uint8ClampedArray(
+				plotscale * wfWidth * 4);  // filled with 0
+			for (var i=0; i<plotscale * wfWidth; i++) {
+				for (var j=0; j<4; j++) {  // r, g, b
+					colorValues[4*i + j] = colormap[17][j];  // white
+				}
+			}
+			let imageData = new ImageData(
+				colorValues, plotscale * wfWidth, 1);
+			for (k=0; k<values * plotscale; k++) {
+				wfCtx.putImageData(imageData, 0, k);
+			}
+			return;
+		}
 		// expand values (4-bit uint per pixel) to colormap values (RGBA per pixel)
 		let colorValues = new Uint8ClampedArray(
 			plotscale * (2 * values.length) * 4);  // filled with 0


### PR DESCRIPTION
A few minor enhancements to the WebGui include:

* Display quality values that were encoded in received DataACK and DataNAK frames.  This can provide additional user awareness of conditions (including changes to DRIVELEVEL or other audio settings) that influence the other station's ability to decode sent data.
* Display additional data from received Ping and PingAck frames.
* Display quality values that are encoded in sent DataACK and DataNAK frames.
* When repeated data frame types are received, this is now indicated with '(REPEAT)' following the frame type displayed.  While this is expected after transmitting a DataNAK, it can also make the user aware of the other station's failure to receive a transmitted DataACK.
* Each time the station transmits, the Spectrum plot is now cleared and a white line is added to the waterfall display.  The cleared spectrum supplements the "PTT" indicator on the Webgui to make it more obvious when the system is transmitting.  This may be useful in situations in which the user can see the Webgui screen, but cannot see or hear indications from the radio that it is transmitting.  Adding a white line to the waterfall leaves a clear indication in that plot of the breaks between periods of received audio.

This PR also fixes a bug that prevented an IDFrame from being sent following RX of an END frame.