### PR TITLE
Bugfix: Avoid undefined strcpy-param-overlap in StartFEC().

### DIFF
--- a/src/common/FEC.c
+++ b/src/common/FEC.c
@@ -92,7 +92,11 @@ BOOL StartFEC(UCHAR * bytData, int Len, char * strDataMode, int intRepeats, BOOL
 	{
 		if (strcmp(strDataMode, strAllDataModes[i]) == 0)
 		{
-			strcpy(strFECMode, strDataMode);
+			if (strcmp(strFECMode, strDataMode) != 0)
+				// This conditional avoids an undefined strcpy-param-overlap
+				// error that would otherwise occur when StartFEC() is called
+				// with strDataMode=strFECMode.
+				strcpy(strFECMode, strDataMode);
 			blnModeOK = TRUE;
 			break;
 		}


### PR DESCRIPTION
Fix a minor bug identified with ASAN/UBSAN as described in Issue #37.