### PR TITLE
Update test_wav_io.py

### DIFF
--- a/src/common/Modulate.c
+++ b/src/common/Modulate.c
@@ -107,7 +107,7 @@ void SendLeaderAndSYNC(UCHAR * bytEncodedBytes, int intLeaderLen)
 			bytMask = bytMask >> 2;
 		}
 	}
-	// Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+	// Include these tone values in debug log only if FileLogLevel is VERBOSE (1)
 	ZF_LOGV("%s", DebugMess);
 }
 
@@ -245,7 +245,7 @@ void Mod4FSKDataAndPlay(int Type, unsigned char * bytEncodedBytes, int Len, int 
 		}
 		intDataPtr += 1;
 	}
-	// Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+	// Include these tone values in debug log only if FileLogLevel is VERBOSE (1)
 	if (intDataBytesPerCar == 0)
 		sprintf(DebugMess + strlen(DebugMess), "(None)");
 	ZF_LOGV("%s", DebugMess);

--- a/src/common/RXO.c
+++ b/src/common/RXO.c
@@ -14,7 +14,7 @@ int wg_send_hostdatat(int cnum, char *prefix, unsigned char *data, int datalen);
 int wg_send_hostdatab(int cnum, char *prefix, unsigned char *data, int datalen);
 
 // Use of RXO is assumed to indicate that the user is interested in observing all received traffic.
-// So LOGINFO, rather than a higher log level such as LOGDEBUG, is used for most positive results.
+// So LOGI (level=3), rather than a lower log level such as LOGD (level=2), is used for most positive results.
 
 // Function to compute the "distance" from a specific bytFrame Xored by bytID using 1 symbol parity
 // The tones representing the Frame Type include two parity symbols which should be identical, and
@@ -93,20 +93,20 @@ BOOL RxoDecodeSessionID(UCHAR bytFrameType, int * intToneMags, float dblMaxDista
 	if (dblDistance > dblMaxDistance)
 	{
 		if (bytID == bytSessionID)
-			ZF_LOGD("[RXO DecodeSessionID FAIL] Decoded ID=H%02hhx Dist=%.2f (%.2f Max). (Matches Prior ID)",
+			ZF_LOGD("[RXO DecodeSessionID FAIL] Decoded ID=H%02hhX Dist=%.2f (%.2f Max). (Matches Prior ID)",
 					bytID, dblDistance, dblMaxDistance);
 		else
-			ZF_LOGD("[RXO DecodeSessionID FAIL] Decoded ID=H%02hhx Dist=%.2f (%.2f Max). (Retain prior ID=H%02X)",
+			ZF_LOGD("[RXO DecodeSessionID FAIL] Decoded ID=H%02hhX Dist=%.2f (%.2f Max). (Retain prior ID=H%02X)",
 					bytID, dblDistance, dblMaxDistance, bytSessionID);
 		return FALSE;
 	}
 	if (bytID == bytSessionID)
 	{
-		ZF_LOGD("[RXO DecodeSessionID OK  ] Decoded ID=H%02hhx Dist=%.2f (%.2f Max). (No change)",
+		ZF_LOGD("[RXO DecodeSessionID OK  ] Decoded ID=H%02hhX Dist=%.2f (%.2f Max). (No change)",
 				bytID, dblDistance, dblMaxDistance);
 	return TRUE;
 	}
-	ZF_LOGI("[RXO DecodeSessionID OK  ] Decoded ID=H%02hhx Dist=%.2f (%.2f Max). (Prior ID=H%02hhx)",
+	ZF_LOGI("[RXO DecodeSessionID OK  ] Decoded ID=H%02hhX Dist=%.2f (%.2f Max). (Prior ID=H%02hhX)",
 			bytID, dblDistance, dblMaxDistance, bytSessionID);
 	bytSessionID = bytID;
 	return TRUE;
@@ -166,40 +166,40 @@ void ProcessRXOFrame(UCHAR bytFrameType, int frameLen, UCHAR * bytData, BOOL bln
 		if (bytFrameType >= 0x31 && bytFrameType <= 0x38)  // ConReq####
 		{
 			// Is there a reason why frameLen is not defined for ConReq?
-			ZF_LOGI("    [RXO %02hhx] ConReq data is callerID targetID", bytSessionID);
+			ZF_LOGI("    [RXO %02hhX] ConReq data is callerID targetID", bytSessionID);
 			frameLen = strlen((char*) bytData);
 		}
 		else if (bytFrameType >= 0x39 && bytFrameType <= 0x3C)  // ConAck####
 		{
-			ZF_LOGI("    [RXO %02hhx] ConAck data is the length (in tens of ms) of the received leader repeated 3 times: %d %d %d",
+			ZF_LOGI("    [RXO %02hhX] ConAck data is the length (in tens of ms) of the received leader repeated 3 times: %d %d %d",
 				bytSessionID, bytFrameData1[0], bytFrameData1[1], bytFrameData1[2]);
 		}
 		else if (bytFrameType == 0x3D)  // PingAck
 		{
-			ZF_LOGI("    [RXO %02hhx] PingAck data is S:N=%d and Quality=%d of the Ping. (Any S:N > 20 is reorted as 21.)",
+			ZF_LOGI("    [RXO %02hhX] PingAck data is S:N=%d and Quality=%d of the Ping. (Any S:N > 20 is reorted as 21.)",
 				bytSessionID, intSNdB, intQuality);
 		}
 		else if (bytFrameType == 0x3E)  // Ping
 		{
-			ZF_LOGI("    [RXO %02hhx] Ping data is caller and target callsigns: '%s'.  While this frame does uses FEC to improve likelihood of correct transmission, it does not include a CRC check with which to confirm correctness.  This Ping was received with S:N=%d, Q=%d.",
+			ZF_LOGI("    [RXO %02hhX] Ping data is caller and target callsigns: '%s'.  While this frame does uses FEC to improve likelihood of correct transmission, it does not include a CRC check with which to confirm correctness.  This Ping was received with S:N=%d, Q=%d.",
 				bytSessionID, bytData, stcLastPingintRcvdSN, stcLastPingintQuality);
 		}
 		else if (bytFrameType >= 0xE0)  // DataACK
 		{
-			ZF_LOGI("    [RXO %02hhx] DataAck FrameType (0x%02X) indicates decode quality (%d/100). 60+ typically required for decoding.",
+			ZF_LOGI("    [RXO %02hhX] DataAck FrameType (0x%02X) indicates decode quality (%d/100). 60+ typically required for decoding.",
 				bytSessionID, bytFrameType, 38 + (2 * (bytFrameType & 0x1F)));
 		}
 		else if (bytFrameType <= 0x1F)  // DataNAK
 		{
-			ZF_LOGI("    [RXO %02hhx] DataNak FrameType (0x%02X) indicates decode quality (%d/100). 60+ typically required for decoding.",
+			ZF_LOGI("    [RXO %02hhX] DataNak FrameType (0x%02X) indicates decode quality (%d/100). 60+ typically required for decoding.",
 				bytSessionID, bytFrameType, 38 + (2 * (bytFrameType & 0x1F)));
 		}
 
-		ZF_LOGI("    [RXO %02hhx] %s frame received OK.  frameLen = %d",
+		ZF_LOGI("    [RXO %02hhX] %s frame received OK.  frameLen = %d",
 				bytSessionID, Name(bytFrameType), frameLen);
 		if (frameLen > 0)
 		{
-			snprintf(strMsg, sizeof(strMsg), "    [RXO %02hhx] %d bytes of data as hex values:\n", bytSessionID, frameLen);
+			snprintf(strMsg, sizeof(strMsg), "    [RXO %02hhX] %d bytes of data as hex values:\n", bytSessionID, frameLen);
 			intMsgLen = strlen(strMsg);
 			for (int i = 0; i < frameLen; i++)
 			{
@@ -216,24 +216,24 @@ void ProcessRXOFrame(UCHAR bytFrameType, int frameLen, UCHAR * bytData, BOOL bln
 					if (bytData[i] == 0x0D && bytData[i + 1] != 0x0A)
 						bytData[i] = 0x0A;
 				}
-				ZF_LOGI("    [RXO %02hhx] %d bytes of data as UTF-8 text:\n%.*s", bytSessionID, frameLen, frameLen, bytData);
+				ZF_LOGI("    [RXO %02hhX] %d bytes of data as UTF-8 text:\n%.*s", bytSessionID, frameLen, frameLen, bytData);
 				if (WG_DevMode)
 					wg_send_hostdatat(0, "RXO", bytData, frameLen);
 			}
 			else {
-				ZF_LOGI("    [RXO %02hhx] Data does not appear to be valid UTF-8 text.", bytSessionID);
+				ZF_LOGI("    [RXO %02hhX] Data does not appear to be valid UTF-8 text.", bytSessionID);
 				if (WG_DevMode)
 					wg_send_hostdatab(0, "RXO", bytData, frameLen);
 			}
 		}
-		snprintf(strMsg, sizeof(strMsg), "STATUS [RXO %02hhx] %s frame received OK.", bytSessionID, Name(bytFrameType));
+		snprintf(strMsg, sizeof(strMsg), "STATUS [RXO %02hhX] %s frame received OK.", bytSessionID, Name(bytFrameType));
 		SendCommandToHost(strMsg);
 	}
 	else
 	{
-		ZF_LOGD("    [RXO %02hhx] %s frame decode FAIL.",
+		ZF_LOGD("    [RXO %02hhX] %s frame decode FAIL.",
 				bytSessionID, Name(bytFrameType));
-		snprintf(strMsg, sizeof(strMsg), "STATUS [RXO %02hhx] %s frame decode FAIL.", bytSessionID, Name(bytFrameType));
+		snprintf(strMsg, sizeof(strMsg), "STATUS [RXO %02hhX] %s frame decode FAIL.", bytSessionID, Name(bytFrameType));
 		SendCommandToHost(strMsg);
 		bytData[frameLen] = 0;
 	}

--- a/src/common/SoundInput.c
+++ b/src/common/SoundInput.c
@@ -1999,7 +1999,7 @@ BOOL DemodFrameType4FSK(int intPtr, short * intSamples, int * intToneMags)
 		else
 			bytSym = 3;
 
-		// Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+		// Include these tone values in debug log only if FileLogLevel is VERBOSE (1)
 		ZF_LOGV("FrameType_bytSym : %d(%d %03.0f/%03.0f/%03.0f/%03.0f)", bytSym, intMagSum, 100.0*intToneMags[4 * i]/intMagSum, 100.0*intToneMags[1 + 4 * i]/intMagSum, 100.0*intToneMags[2 + 4 * i]/intMagSum, 100.0*intToneMags[3 + 4 * i]/intMagSum);
 	}
 
@@ -2532,7 +2532,7 @@ void Demod1Car4FSK_SDFT(int Start, BOOL blnGetFrameType)
 			}
 			bytCharValue = (bytCharValue << 2) + bytSym;
 		}
-		// Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+		// Include these tone values in debug log only if FileLogLevel is VERBOSE (1)
 		ZF_LOGV(
 			"Demod4FSK %d(%03.0f/%03.0f/%03.0f/%03.0f) [timing_advance=%d : avg %.02f per symbol]",
 			bytSym,
@@ -2635,7 +2635,7 @@ void Demod1Car4FSKChar(int Start, UCHAR * Decoded)
 		Start += intSampPerSym;  // advance the pointer one symbol
 	}
 
-	// Include these tone values in debug log only if FileLogLevel is LOGDEBUGPLUS
+	// Include these tone values in debug log only if FileLogLevel is VERBOSE (1)
 	ZF_LOGV("%s", DebugMess);
 	if (AccumulateStats)
 		intFSKSymbolCnt += 4;

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -32,6 +32,14 @@
 #define _POSIX_C_SOURCE 200809L
 #include <time.h>
 
+/* Size of the log line buffer. The buffer is allocated on stack. It limits
+ * maximum length of a log line.  (Default is 512)
+ * Set long enough to log the maximum 1024 bytes of data that is encoded in
+ * any data frame as hex with spaces between bytes (so 3 printed bytes per data
+ * byte) plus with some margin.
+ */
+#define ZF_LOG_BUF_SZ 4000
+
 /* UTC log timestamps */
 #define ZF_LOG_USE_UTC_TIME 1
 

--- a/test/python/test_wav_io.py
+++ b/test/python/test_wav_io.py
@@ -33,8 +33,10 @@ def test_contol_wav_io(verbose=1):
         res = subprocess.run(
             [
                 APATH,
-                # --logdir sets the location of the debug log and the
-                # WAV files to be written.
+                # --nologfile prevents the creation of a log file which
+                # is not needed for this testing.
+                "--nologfile",
+                # --logdir sets the location of the WAV files written.
                 "--logdir",
                 TMPPATH,
                 "--writetxwav",
@@ -44,18 +46,16 @@ def test_contol_wav_io(verbose=1):
                 # Whenever audio devices are specified, host port
                 # number must also be specified.
                 "8515", "NOSOUND", "NOSOUND",
-                # LOGLEVEL 0 (LOGEMERGENCY) should prevent most writes
-                # to the log file, which is not used for this testing.
-                # CONSOLELOG 7 (LOGDEBUG) ensures that filename of
-                # the WAV is written to stdout so that it can be
-                # parsed from res.stdout.
+                # CONSOLELOG 2 ensures that the filename of the WAV is
+                # written to stdout so that it can be parsed from
+                # res.stdout.
                 # DRIVELEVEL 30 reduces the volume of the signal in the
                 # WAV file.  This is not expected to impact the ability
                 # of ardopcf to demodulate/decode this WAV file, but it
                 # may be useful if a later stage of this testing uses
                 # noise added to the recording.
                 "--hostcommands",
-                f'LOGLEVEL 0;CONSOLELOG 7;DRIVELEVEL 30;TXFRAME'
+                f'CONSOLELOG 2;DRIVELEVEL 30;TXFRAME'
                 f' {frametype} {paramstr};CLOSE',
             ],
             capture_output=True,
@@ -82,23 +82,22 @@ def test_contol_wav_io(verbose=1):
                 res = subprocess.run(
                     [
                         APATH,
-                        # --logdir sets the location of the debug log and the
-                        # WAV files to be written.
-                        "--logdir",
-                        TMPPATH,
+                        # --nologfile prevents the creation of a log
+                        # file which is not needed for this testing.
+                        "--nologfile",
                         "--decodewav",
                         wavpath,
                         # When sdftstr is "", the standard demodulators
                         # are used.  When it is "--sdft", the
                         # experimental SDFT demodulator is used.
                         sdftstr,
-                        "--hostcommands",
-                        # LOGLEVEL 0 (LOGEMERGENCY) should prevent most writes
-                        # to the log file, which is not used for this testing.
-                        # CONSOLELOG 7 (LOGDEBUG) ensures that [DecodeFrame] and
+                        # CONSOLELOG 2 ensures that [DecodeFrame] and
                         # [Frame Type Decode Fail] are written to stdout as well
                         # as the hex representation of the decoded data.
-                        'LOGLEVEL 0;CONSOLELOG 7',
+                        "--hostcommands",
+                        'CONSOLELOG 2',
+                        # No port number or sound devices are required
+                        # when using the --decodewav option.
                     ],
                     capture_output=True,
                     check=True,
@@ -156,21 +155,6 @@ def test_contol_wav_io(verbose=1):
             print("No failures occured in test_contol_wav_io().")
     return faillist
 
-
-QAM2000_NOTE = (
-    "NOTE: Using ardopcf v1.0.4.1.2+develop, current as of the initial"
-    " use of this test script, one or more of the 16QAM.2000.100 frames"
-    " usually fail to be decoded properly during this test.  These are"
-    " the fastest and least robust of the ardop data frame types.  Even"
-    " when decoded correctly, the large number of RS errors corrected is"
-    " high, except when the fill level of the frame is low.  This"
-    " indicates poor performance of the demodulator that must be"
-    " compensated for by the large amount of forward error correction"
-    " used.  It is unclear at this time whether this mode is simply too"
-    " fragile for the algorithms and parameters being used, or whether"
-    " there is an as yet unidentified bug in ardopcf, which will improve"
-    " the usefulness of this frame type once it is fixed."
-)
 
 def parse_ber_results(logstr, cars, print_bermap=False):
     """For each carrier, print the Bit Error Rate data"""
@@ -233,23 +217,23 @@ def test_data_wav_io(verbose=1, sessionid=0xFF):
                 res = subprocess.run(
                     [
                         APATH,
-                        # --logdir sets the location of the debug log and the
-                        # WAV files to be written.
+                        # --nologfile prevents the creation of a log
+                        # file which is not needed for this testing.
+                        "--nologfile",
+                        # --logdir sets the location of the WAV files written.
                         "--logdir",
                         TMPPATH,
                         "--writetxwav",
-                        # LOGLEVEL 0 (LOGEMERGENCY) should prevent most writes
-                        # to the log file, which is not used for this testing.
-                        # CONSOLELOG 7 (LOGDEBUG) ensures that filename of
-                        # the WAV is written to stdout so that it can be
-                        # parsed from res.stdout.
+                        # CONSOLELOG 2 ensures that the filename of the WAV is
+                        # written to stdout so that it can be parsed from
+                        # res.stdout.
                         # DRIVELEVEL 30 reduces the volume of the signal in the
                         # WAV file.  This is not expected to impact the ability
                         # of ardopcf to demodulate/decode this WAV file, but it
                         # may be useful if a later stage of this testing uses
                         # noise added to the recording.
                         "--hostcommands",
-                        f'LOGLEVEL 0;CONSOLELOG 7;DRIVELEVEL 30;TXFRAME'
+                        f'CONSOLELOG 2;DRIVELEVEL 30;TXFRAME'
                         f' {frametype[:-1]}{suffix} {rdatahex}'
                         f' 0x{hex(sessionid)[2:]:>02};CLOSE',
                         # Using special audio device name "NOSOUND" tells
@@ -275,8 +259,7 @@ def test_data_wav_io(verbose=1, sessionid=0xFF):
                         print("stderr:\n", res.stdout.decode("iso-8859-1"))
                     faillist.append(
                         f"ERROR parsing stdout from encoding {frametype[:-1]}"
-                        f"{suffix} ({payload_used}/{payload_capacity} bytes)"
-                        f" {sdftstr}")
+                        f"{suffix} ({payload_used}/{payload_capacity} bytes)")
                     fail = True
                     continue
                 wavpath = m.group(1)
@@ -286,10 +269,9 @@ def test_data_wav_io(verbose=1, sessionid=0xFF):
                         res = subprocess.run(
                             [
                                 APATH,
-                                # --logdir sets the location of the debug log and
-                                # the WAV files to be written.
-                                "--logdir",
-                                TMPPATH,
+                                # --nologfile prevents the creation of a log
+                                # file which is not needed for this testing.
+                                "--nologfile",
                                 "--decodewav",
                                 wavpath,
                                 # When sdftstr is "", the standard demodulators
@@ -299,16 +281,13 @@ def test_data_wav_io(verbose=1, sessionid=0xFF):
                                 # frame type header for all data frames.
                                 sdftstr,
                                 "--hostcommands",
-                                # LOGLEVEL 0 (LOGEMERGENCY) should prevent most
-                                # writes to the log file, which is not used for
-                                # this testing.
-                                # CONSOLELOG 8 (LOGDEBUGPLUS) ensures that
+                                # CONSOLELOG 1 ensures that
                                 # [DecodeFrame] and [Frame Type Decode Fail],
                                 # the hex representation of the decoded data,
                                 # and Bit Error results are written to stdout so
                                 # that they can be parsed from res.stdout.
-                                'LOGLEVEL 0;CONSOLELOG 8',
-                                # No port number of sound devices are required
+                                'CONSOLELOG 1',
+                                # No port number or sound devices are required
                                 # when using the --decodewav option.
                             ],
                             capture_output=True,
@@ -359,11 +338,6 @@ def test_data_wav_io(verbose=1, sessionid=0xFF):
                                 print(
                                     "This error occured when the experiemental"
                                     " SDFT demodulator was used.")
-
-                            if frametype == "16QAM.2000.100.E":
-                                print(
-                                    "NOTE: This failure is not unexpected.  See"
-                                    " note included in summary for more detail.")
                             if verbose > 1:
                                 parse_ber_results(
                                     res.stdout.decode("iso-8859-1"),
@@ -399,7 +373,7 @@ def test_data_wav_io(verbose=1, sessionid=0xFF):
                     # hex string so that it can be compared to the encoded data.
                     m = re.search(
                         r"\[RXO ([0-9A-F][0-9A-F])\] ([0-9]+) bytes of data as"
-                        r" hex values:\s([0-9A-F ]+)\s\s+",
+                        r" hex values:\s+([0-9A-F ]+)\s\s+",
                         res.stdout.decode("iso-8859-1")
                     )
                     if m is None:
@@ -465,7 +439,6 @@ def test_data_wav_io(verbose=1, sessionid=0xFF):
             print(f"{len(faillist)} failures occured in test_data_wav_io().")
             for failnum, failstr in enumerate(faillist):
                 print(f"{failnum + 1}.  {failstr}")
-            print(QAM2000_NOTE)
         else:
             print("No failures occured in test_data_wav_io().")
     return faillist
@@ -495,6 +468,5 @@ if __name__ == '__main__':
         print(f"\n{len(full_faillist)} failures occured in test_wav_io.py.")
         for failnum, failstr in enumerate(full_faillist):
             print(f"{failnum + 1}.  {failstr}")
-        print(QAM2000_NOTE)
     else:
         print("\nNo failures occured in test_wav_io.py.")


### PR DESCRIPTION
The recent rewrite of logging required test_wav_io.py to be updated since it parses logging to the console to asses the operation of ardopcf.  

While updating test_wav_io.py, a couple of unintended changes caused by the recent changes were identified and corrected.  Among these, lines of text to be logged were truncated at 512 bytes.  This was insufficient to accommodate some of the verbose logging of details about decoded frames.  So, this limit was increased to 4000 bytes.