### PR TITLE
Introduce Locator object for Maidenhead Grid Square

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,9 @@ OBJS = \
 	src/common/FEC.o \
 	src/common/FFT.o \
 	src/common/HostInterface.o \
-	src/common/log.o \
+	src/common/Locator.o \
 	src/common/log_file.o \
+	src/common/log.o \
 	src/common/Modulate.o \
 	src/common/Packed6.o \
 	src/common/RXO.o \
@@ -87,6 +88,7 @@ OBJS_EXE = \
 TESTS = \
 	test/ardop/test_ARDOPC \
 	test/ardop/test_ARDOPCommon \
+	test/ardop/test_Locator \
 	test/ardop/test_log \
 	test/ardop/test_Packed6 \
 

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ OBJS = \
 	src/common/log.o \
 	src/common/log_file.o \
 	src/common/Modulate.o \
+	src/common/Packed6.o \
 	src/common/RXO.o \
 	src/common/sdft.o \
 	src/common/SoundInput.o \
@@ -87,6 +88,7 @@ TESTS = \
 	test/ardop/test_ARDOPC \
 	test/ardop/test_ARDOPCommon \
 	test/ardop/test_log \
+	test/ardop/test_Packed6 \
 
 # unit test common code
 TEST_OBJS_COMMON = \

--- a/src/common/ARDOPC.h
+++ b/src/common/ARDOPC.h
@@ -2,6 +2,7 @@
 #define ARDOPCHEADERDEFINED
 
 #include "common/log.h"
+#include "common/Locator.h"
 
 extern const char ProductName[];
 extern const char ProductVersion[];
@@ -125,7 +126,7 @@ void ClearDataToSend();
 int EncodeFSKData(UCHAR bytFrameType, UCHAR * bytDataToSend, int Length, unsigned char * bytEncodedBytes);
 int EncodePSKData(UCHAR bytFrameType, UCHAR * bytDataToSend, int Length, unsigned char * bytEncodedBytes);
 int EncodePing(char * strMyCallsign, char * strTargetCallsign, UCHAR * bytReturn);
-int Encode4FSKIDFrame(char * Callsign, char * Square, unsigned char * bytreturn);
+int Encode4FSKIDFrame(char * Callsign, const Locator* square, unsigned char * bytreturn);
 int EncodeDATAACK(int intQuality, UCHAR bytSessionID, UCHAR * bytreturn);
 int EncodeDATANAK(int intQuality , UCHAR bytSessionID, UCHAR * bytreturn);
 void Mod4FSKDataAndPlay(int Type, unsigned char * bytEncodedBytes, int Len, int intLeaderLen);
@@ -202,7 +203,6 @@ extern void Generate50BaudTwoToneLeaderTemplate();
 extern BOOL blnDISCRepeating;
 
 void DeCompressCallsign(const char * bytCallsign, char * returned, size_t returnlen);
-void DeCompressGridSquare(char * bytGS, char * returned);
 void ProcessRcvdFECDataFrame(int intFrameType, UCHAR * bytData, BOOL blnFrameDecodedOK);
 void ProcessUnconnectedConReqFrame(int intFrameType, UCHAR * bytData);
 void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL blnFrameDecodedOK);
@@ -381,7 +381,7 @@ extern const short intFSK600bdCarTemplate[4][20];  // Template for 4FSK carriers
 #define AUXCALLS_ALEN 10  // length of AuxCalls array
 #define COMP_SIZE 6  // size of compressed callsign or gridsquare
 // Config Params
-extern char GridSquare[9];
+extern Locator GridSquare;
 extern char Callsign[CALL_BUF_SIZE];
 extern BOOL wantCWID;
 extern BOOL CWOnOff;

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -1521,7 +1521,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				if (CheckValidCallsignSyntax(strLocalCallsign))
 				{
 					dttLastFECIDSent = Now;
-					if ((EncLen = Encode4FSKIDFrame(strLocalCallsign, GridSquare, bytEncodedBytes)) <= 0) {
+					if ((EncLen = Encode4FSKIDFrame(strLocalCallsign, &GridSquare, bytEncodedBytes)) <= 0) {
 						ZF_LOGE("ERROR: In ProcessRcvdARQFrame() for END->IDFrame Invalid EncLen (%d).", EncLen);
 						return;
 					}
@@ -1808,7 +1808,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 			if (CheckValidCallsignSyntax(strLocalCallsign))
 			{
 				dttLastFECIDSent = Now;
-				if ((EncLen = Encode4FSKIDFrame(strLocalCallsign, GridSquare, bytEncodedBytes)) <= 0) {
+				if ((EncLen = Encode4FSKIDFrame(strLocalCallsign, &GridSquare, bytEncodedBytes)) <= 0) {
 					ZF_LOGE("ERROR: In ProcessRcvdARQFrame() for END->IDFrame Invalid EncLen (%d).", EncLen);
 					return;
 				}
@@ -2196,7 +2196,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				if (CheckValidCallsignSyntax(strLocalCallsign))
 				{
 					dttLastFECIDSent = Now;
-					if ((EncLen = Encode4FSKIDFrame(strLocalCallsign, GridSquare, bytEncodedBytes)) <= 0) {
+					if ((EncLen = Encode4FSKIDFrame(strLocalCallsign, &GridSquare, bytEncodedBytes)) <= 0) {
 						ZF_LOGE("ERROR: In ProcessRcvdARQFrame() for END->IDFrame Invalid EncLen (%d).", EncLen);
 						return;
 					}
@@ -2423,7 +2423,7 @@ BOOL Send10MinID()
 		blnEnbARQRpt = FALSE;
 
 		dttLastFECIDSent = Now;
-		if ((EncLen = Encode4FSKIDFrame(strLocalCallsign, GridSquare, bytEncodedBytes)) <= 0) {
+		if ((EncLen = Encode4FSKIDFrame(strLocalCallsign, &GridSquare, bytEncodedBytes)) <= 0) {
 			ZF_LOGE("ERROR: In Send10MinID() Invalid EncLen (%d).", EncLen);
 			return FALSE;
 		}

--- a/src/common/FEC.c
+++ b/src/common/FEC.c
@@ -296,7 +296,7 @@ sendit:
 
 			unsigned char bytEncodedBytes[16];
 
-			if ((EncLen = Encode4FSKIDFrame(Callsign, GridSquare, bytEncodedBytes)) <= 0) {
+			if ((EncLen = Encode4FSKIDFrame(Callsign, &GridSquare, bytEncodedBytes)) <= 0) {
 				ZF_LOGE("ERROR: In GetNextFECFrame() IDFrame Invalid EncLen (%d).", EncLen);
 				return FALSE;
 			}

--- a/src/common/HostInterface.c
+++ b/src/common/HostInterface.c
@@ -725,18 +725,21 @@ void ProcessCommandFromHost(char * strCMD)
 	{
 		if (ptrParams == 0)
 		{
-			sprintf(cmdReply, "%s %s", strCMD, GridSquare);
+			snprintf(cmdReply, sizeof(cmdReply), "%s %s", strCMD, GridSquare.grid);
 			SendReplyToHost(cmdReply);
 		}
 		else
-			if (CheckGSSyntax(ptrParams))
-			{
-				strcpy(GridSquare, ptrParams);
-				sprintf(cmdReply, "%s now %s", strCMD, GridSquare);
+		{
+			Locator inp;
+			locator_err e = locator_from_str(ptrParams, &inp);
+			if (e) {
+				snprintf(strFault, sizeof(strFault), "Syntax Err: %s %s: %s", strCMD, ptrParams, locator_strerror(e));
+			} else {
+				memcpy(&GridSquare, &inp, sizeof(GridSquare));
+				snprintf(cmdReply, sizeof(cmdReply), "%s now %s", strCMD, GridSquare.grid);
 				SendReplyToHost(cmdReply);
 			}
-			else
-				snprintf(strFault, sizeof(strFault), "Syntax Err: %s %s", strCMD, ptrParams);
+		}
 
 		goto cmddone;
 	}

--- a/src/common/Locator.c
+++ b/src/common/Locator.c
@@ -1,0 +1,230 @@
+#include "common/Locator.h"
+
+#include <assert.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+// Legacy ARDOPC used to transmit "No GS" in IDFRAMEs to indicate
+// that the grid square is unset. This is *not* valid as a
+// Packed6 since it was actually encoded with a lowercase "o."
+//
+// To support this, we quietly accept any of the following
+// byte sequences as an unset grid square.
+const static Packed6 LOCATOR_NOGS[] = {
+	{{0xbc, 0xf0, 0x27, 0xcc, 0x00, 0x00}},
+	{{0xba, 0xf0, 0x27, 0xcc, 0x00, 0x00}},
+};
+
+/**
+ * Validate locator
+ *
+ * Validate the `grid` field of the given `locator`.
+ *
+ * Returns LOCATOR_OK if the locator is valid or some
+ * other value if it is not.
+ */
+ARDOP_MUSTUSE locator_err
+locator_validate_grid(const Locator* locator);
+
+// true if s is ASCII alphabetical with the given
+// ending character `end`. For example, set `end = 'R'`
+// to accept alphabet characters A through R. `end` must
+// be uppercase.
+//
+// NOTE: ctype.h functions respect the current locale, and
+// we do *not* want that since it might not be an English
+// locale
+inline static bool is_ascii_alpha_range(const char s, const char end) {
+	const char LOWERCASE_ADD = 'a' - 'A';
+
+	bool upper = s >= 'A' && s <= end;
+	bool lower = s >= ('A' + LOWERCASE_ADD) && s <= (end + LOWERCASE_ADD);
+	return (upper || lower);
+}
+
+// convert given character to ASCII lowercase
+//
+// NOTE: ctype.h tolower() respects the current locale, and
+// we do *not* want that since it might not be an English
+// locale
+inline static char to_ascii_lowercase(const char s) {
+	const char LOWERCASE_ADD = 'a' - 'A';
+
+	if (s >= 'A' && s <= 'Z') {
+		return (char)(s + LOWERCASE_ADD);
+	} else {
+		return s;
+	}
+}
+
+// true if s is ASCII digit
+inline static bool is_ascii_digit(const char s) {
+	return s >= '0' && s <= '9';
+}
+
+// compress the grid square
+// the `grid` field must be populated
+static locator_err locator_compress(const Locator* locator, Packed6* out) {
+	locator_err res = locator_validate_grid(locator);
+	if (res) {
+		return res;
+	}
+
+	if (!packed6_from_str_slice(locator->grid, sizeof(locator->grid) - 1, out)) {
+		return LOCATOR_ERR_FMT_CHARSET;
+	}
+
+	return LOCATOR_OK;
+}
+
+// uncompress `grid` square from a Packed6
+// the wire bytes must be populated
+static locator_err locator_uncompress(const Packed6* in, Locator* locator) {
+	// check for legacy "unset gridsquare" byte sequence
+	for (size_t ind = 0; ind < sizeof(LOCATOR_NOGS)/sizeof(LOCATOR_NOGS[0]); ++ind) {
+		if (0 == memcmp(in, &LOCATOR_NOGS[ind], sizeof(*in))) {
+			locator_init(locator);
+			return LOCATOR_OK;
+		}
+	}
+
+	packed6_to_fixed_str(in, locator->grid);
+
+	// translate second letter pair to lowercase
+	for (size_t i = 4; i < 6; ++i) {
+		locator->grid[i] = to_ascii_lowercase(locator->grid[i]);
+	}
+
+	// translate space to NUL, which will truncate the grid square
+	for (size_t i = 0; i < sizeof(locator->grid); ++i) {
+		if (locator->grid[i] == ' ') {
+			locator->grid[i] = 0;
+		}
+	}
+
+	return locator_validate_grid(locator);
+}
+
+ARDOP_MUSTUSE locator_err
+locator_validate_grid(const Locator* locator) {
+	size_t len = strnlen(locator->grid, sizeof(locator->grid));
+	if (len % 2 != 0) {
+		return LOCATOR_ERR_FMT_LENGTH;
+	}
+
+	for (size_t i = 0; i < len; ++i) {
+		switch (i/2) {
+			case 0:
+				// field A – R
+				if (! is_ascii_alpha_range(locator->grid[i], 'R'))
+					return LOCATOR_ERR_FMT_FIELD;
+				break;
+			case 1:
+				// square 0 – 9
+				if (! is_ascii_digit(locator->grid[i]))
+					return LOCATOR_ERR_FMT_SQUARE;
+				break;
+			case 2:
+				// subsquare A – X
+				if (! is_ascii_alpha_range(locator->grid[i], 'X'))
+					return LOCATOR_ERR_FMT_SUBSQUARE;
+				break;
+			default:
+				// extended square, 0 – 9
+				if (! is_ascii_digit(locator->grid[i]))
+					return LOCATOR_ERR_FMT_EXTSQUARE;
+				break;
+		}
+	}
+
+	return LOCATOR_OK;
+}
+
+void locator_init(Locator* locator) {
+	memset(locator, 0, sizeof(*locator));
+}
+
+locator_err locator_from_str(const char* str, Locator* locator) {
+	const char* inp = str ? str : "";
+	size_t len = strlen(inp);
+	return locator_from_str_slice(inp, len, locator);
+}
+
+locator_err locator_from_str_slice(const char* str, size_t len, Locator* locator) {
+	locator_err out = LOCATOR_OK;
+
+	// empty grid is OK
+	if (len == 0)
+		return out;
+
+	// copy string, checking for truncation
+	int ck = snprintf(locator->grid, sizeof(locator->grid), "%.*s", (int)len, str);
+	if (ck <= 0 || ck >= sizeof(locator->grid)) {
+		locator_init(locator);
+		return LOCATOR_ERR_TOOLONG;
+	}
+
+	// validate and compress
+	out = locator_compress(locator, &locator->wire);
+	if (out) {
+		locator_init(locator);
+		return out;
+	}
+
+	// canonicalize by uncompressing
+	out = locator_uncompress(&locator->wire, locator);
+	if (out) {
+		locator_init(locator);
+		return out;
+	}
+
+	return out;
+}
+
+const Packed6* locator_as_bytes(const Locator* locator) {
+	if (!! locator && locator_is_populated(locator)) {
+		return &(locator->wire);
+	} else {
+		return &LOCATOR_NOGS[1];
+	}
+}
+
+locator_err locator_from_bytes(const uint8_t bytes[PACKED6_SIZE], Locator* locator) {
+	locator_init(locator);
+
+	// read Packed6
+	packed6_from_bytes(bytes, &locator->wire);
+
+	// decompress and validate
+	locator_err out = locator_uncompress(&locator->wire, locator);
+	if (out) {
+		locator_init(locator);
+		return out;
+	}
+
+	return out;
+}
+
+bool locator_is_populated(const Locator* locator) {
+	return locator->grid[0] != '\0';
+}
+
+const char* locator_strerror(locator_err err) {
+	const static char* MSGS[] = {
+		"unknown error",
+		"length exceeded",
+		"locator must be 2, 4, 6, or 8 characters",
+		"locator uses invalid characters",
+		"locator has invalid field (first pair)",
+		"locator has invalid square (second pair)",
+		"locator has invalid subsquare (third pair)",
+		"locator has invalid extended square (fourth pair)",
+	};
+
+	static_assert(sizeof(MSGS) / sizeof(MSGS[0]) == LOCATOR_ERR_MAX_, "error string size mismatch");
+	if (err >= LOCATOR_ERR_MAX_)
+		return MSGS[0];
+
+	return MSGS[err];
+}

--- a/src/common/Locator.h
+++ b/src/common/Locator.h
@@ -1,0 +1,237 @@
+#ifndef ARDOP_COMMON_LOCATOR_H_
+#define ARDOP_COMMON_LOCATOR_H_
+
+#include <stdint.h>
+
+#include "common/mustuse.h"
+#include "common/Packed6.h"
+
+/**
+ * @def LOCATOR_SIZE
+ * @brief LOCATOR_SIZE
+ *
+ * Maximum size of the string representation of a Locator,
+ * including the trailing NUL.
+ */
+#define LOCATOR_SIZE 9
+
+/**
+ * @brief Error codes returned by Locator functions
+ */
+typedef enum {
+	/**
+	 * @brief The Locator is accepted
+	 *
+	 * A `LOCATOR_OK` may still be empty
+	 */
+	LOCATOR_OK = 0,
+
+	/**
+	 * @brief The Locator is too long
+	 */
+	LOCATOR_ERR_TOOLONG = 1,
+
+	/**
+	 * @brief The Locator does not contain an even number of characters
+	 *
+	 * Grid squares which are not 2, 4, 6, or 8-characters are invalid.
+	 */
+	LOCATOR_ERR_FMT_LENGTH = 2,
+
+	/**
+	 * @brief The Locator uses invalid characters
+	 */
+	LOCATOR_ERR_FMT_CHARSET = 3,
+
+	/**
+	 * @brief The Locator has an invalid first part
+	 */
+	LOCATOR_ERR_FMT_FIELD = 4,
+
+	/**
+	 * @brief The Locator has an invalid second part
+	 */
+	LOCATOR_ERR_FMT_SQUARE = 5,
+
+	/**
+	 * @brief The Locator has an invalid third part
+	 */
+	LOCATOR_ERR_FMT_SUBSQUARE = 6,
+
+	/**
+	 * @brief The Locator has an invalid fourth part
+	 */
+	LOCATOR_ERR_FMT_EXTSQUARE = 7,
+
+	LOCATOR_ERR_MAX_ = 8,
+} locator_err;
+
+/**
+ * @brief Maidenhead Locator System
+ *
+ * Identifies the Maidenhead Locator System grid square of an
+ * ARDOP station. The grid square is an optional protocol feature
+ * which is strongly encouraged. A failure to transmit and/or
+ * decode the grid square does \em not void the frame.
+ *
+ * Maidenhead grid squares like `BL11BH16` have the following
+ * format:
+ *
+ * | Example | What                 | Range  | Size (geodetic) |
+ * |---------|----------------------|--------|-----------------|
+ * |       B | Field, longitude     | A–R    | 20°             |
+ * |       L | Field, latitude      | A–R    | 10°             |
+ * |       1 | Square, longitude    | 0–9    | 2°              |
+ * |       1 | Square, latitude     | 0–9    | 1°              |
+ * |       b | Subsquare, longitude | a–x    | 5 min           |
+ * |       h | Subsquare, latitude  | a–x    | 2.5 min         |
+ * |       1 | Extended square, lon | 0–9    | 30 sec          |
+ * |       6 | Extended square, lat | 0–9    | 15 sec          |
+ *
+ * In the 8-character representation, the Earth is divided into
+ * a total of 43200 longitude squares and 43200 latitude squares.
+ *
+ * ARDOP, like many other programs, uses the lowercase
+ * representation of the second letter pair.
+ */
+typedef struct {
+	/**
+	 * @brief Maidenhead Locator System Grid Square
+	 *
+	 * The human-readable `grid` square is a string of zero, two,
+	 * four, six, or eight characters like `BL11bh16`, alternating
+	 * between letters and digits. If no grid square was provided,
+	 * this will be the empty string.
+	 */
+	char grid[LOCATOR_SIZE];
+
+	/**
+	 * @brief Wireline representation
+	 *
+	 * A compressed representation suitable for transmitting
+	 * in ARDOP protocol frames. The compressed representation
+	 * is always 6 bytes long.
+	 *
+	 * @warning Instead of accessing this field directly, use
+	 * \ref locator_as_bytes().
+	 */
+	Packed6 wire;
+} Locator;
+
+/**
+ * @brief Create empty locator
+ *
+ * The given `locator` is initialized to empty. The empty
+ * locator is valid for all frames but conveys no useful
+ * information.
+ *
+ * @param[in] locator    Locator to zeroize.
+ */
+void locator_init(Locator* locator);
+
+/**
+ * @brief Create a locator from a string
+ *
+ * Accepts a string of the form "`BL11bh16`" and parses it into a
+ * Maidenhead Grid Square. If this method returns zero, the grid
+ * square is valid and is ready to be transmitted.
+ *
+ * The grid square is canonicalized with a round-trip through
+ * the compression and decompression algorithm. Lowercase letters
+ * are silently converted to uppercase.
+ *
+ * @param[in]  str      Null-terminated C string, which must be
+ *                      a valid grid square of length 0, 2, 4, 6,
+ *                      or 8.
+ * @param[out] locator  Constructed locator
+ *
+ * @return zero if the input was parsed into a valid locator or a
+ * non-zero value if it was not. The entry in \ref locator_err
+ * indicates the exact error that occurred. If this method returns
+ * an error, `locator` will represent the empty grid square.
+ */
+ARDOP_MUSTUSE locator_err
+locator_from_str(const char* str, Locator* locator);
+
+/**
+ * @brief Create a locator from a bounded string
+ *
+ * Accepts a string of the form "`BL11bh16`" and parses it into a
+ * Maidenhead Grid Square. If this method returns zero, the grid
+ * square is valid and is ready to be transmitted.
+ *
+ * The grid square is canonicalized with a round-trip through
+ * the compression and decompression algorithm. Lowercase letters
+ * are silently converted to uppercase.
+ *
+ * @param[in]  str      C string, which must be a valid
+ *                      grid square of length 0, 2, 4, 6, or 8
+ *                      (NUL termination optional)
+ * @param[in]  len      Number of characters in `str`, per `strlen()`
+ * @param[out] locator  Constructed locator
+ *
+ * @return zero if the input was parsed into a valid locator or a
+ * non-zero value if it was not. The entry in \ref locator_err
+ * indicates the exact error that occurred. If this method returns
+ * an error, `locator` will represent the empty grid square.
+ */
+ARDOP_MUSTUSE locator_err
+locator_from_str_slice(const char* str, size_t len, Locator* locator);
+
+/**
+ * @brief Create a locator from wireline bytes
+ *
+ * Creates a Locator from a byte buffer. `bytes` must have at
+ * least 6 bytes available for reading. If this method
+ * returns zero, all fields of the Locator are populated and
+ * are ready for either user display or frame transmission.
+ *
+ * Not all byte sequences represent valid locators, and
+ * locators may fail to decode. Failure to decode the Locator
+ * does \em not void the frame.
+ *
+ * @param[in]  bytes    Packed bytes. This method requires
+ *                      *exactly* six bytes from `bytes`.
+ * @param[out] locator  Decoded locator
+ *
+ * @return zero if the input was parsed into a valid locator or a
+ * non-zero value if it was not. The entry in \ref locator_err
+ * indicates the exact error that occurred. If this method returns
+ * an error, `locator` will represent the empty grid square.
+ */
+ARDOP_MUSTUSE locator_err
+locator_from_bytes(const uint8_t bytes[PACKED6_SIZE], Locator* locator);
+
+/**
+ * @brief Return wireline bytes for transmission
+ *
+ * Returns the compressed representation of this `locator`.
+ * If the locator is unpopulated or a nullptr, returns a special
+ * "`NO GS`" byte sequence to use in place of a grid square.
+ *
+ * @return A struct which contains the wireline representation
+ * of `locator`. The return value is cast-compatible with a
+ * `uint8_t[6]`.
+ */
+const Packed6* locator_as_bytes(const Locator* locator);
+
+/**
+ * @brief True if the Locator is populated
+ *
+ * @return true if the locator is populated and valid or false
+ * if otherwise. The empty locator will return false.
+ */
+bool locator_is_populated(const Locator* locator);
+
+/**
+ * @brief Obtain human-readable explanation for the given error
+ *
+ * @param[in] err An error code from a locator function
+ *
+ * @return Error string. This method will always return a
+ * non-nullptr NUL-terminated string with a static lifetime.
+ */
+const char* locator_strerror(locator_err err);
+
+
+#endif /* ARDOP_COMMON_LOCATOR_H_ */

--- a/src/common/Packed6.c
+++ b/src/common/Packed6.c
@@ -1,0 +1,135 @@
+#include "common/Packed6.h"
+
+#include <string.h>
+#include <stdio.h>
+
+// Converts vector of exactly four characters to a vector of exactly
+// three bytes using DEC SIXBIT compression. The compressed
+// alphabet can only represent ASCII character 32 (space) through
+// ASCII character 63 (underscore). Returns false if any character
+// is not representable.
+static bool compress_four_to_three(
+	const char uncompressed[4], uint8_t compressed[3])
+{
+	const uint8_t SPACE = (uint8_t)' ';
+	const uint8_t UNDERSCORE = (uint8_t)'_';
+	const uint8_t UPPERCASE_A = (uint8_t)'A';
+	const uint8_t LOWERCASE_A = (uint8_t)'a';
+	const uint8_t LOWERCASE_Z = (uint8_t)'z';
+	const uint8_t LOWER6 = (uint8_t)(0x3F);
+	const uint32_t BYTE = (uint32_t)(0xFF);
+
+	bool ok = true;
+	uint32_t pack = 0;
+
+	for (size_t ipos = 0; ipos < 4; ++ipos) {
+		uint8_t b = (uint8_t)uncompressed[ipos];
+		if (b >= SPACE && b <= UNDERSCORE) {
+			// packed alphabet starts at ASCII 32 (space)
+			// use characters in this range verbatim
+			b = b - SPACE;
+		}
+		else if (b >= LOWERCASE_A && b <= LOWERCASE_Z) {
+			// lowercase → uppercase
+			b = b - (LOWERCASE_A - UPPERCASE_A) - SPACE;
+		} else {
+			// out of range; replace with space
+			b = 0;
+			ok = false;
+		}
+
+		// take only the lower 6 bits and store them
+		// in the next-highest 6 bits of the pack word
+		pack = pack << 6;
+		pack |= ((uint32_t)(b & LOWER6));
+	}
+
+	// shift one byte at a time off the pack word, starting
+	// with the lowest byte (end of data).
+	for (size_t opos = 0; opos < 3; ++opos) {
+		compressed[2 - opos] = pack & BYTE;
+		pack = pack >> 8;
+	}
+
+	return ok;
+}
+
+// Converts vector of exactly three bytes to a vector of exactly
+// four ASCII characters using DEC SIXBIT decompression. This
+// undoes compress_four_to_three(). This method always succeeds.
+//
+// The output is *NOT* NUL-terminated
+static void decompress_three_to_four(
+	const uint8_t compressed[3], char uncompressed[4])
+{
+	const uint8_t SPACE = (uint8_t)' ';
+	const uint32_t LOWER6 = (uint32_t)(0x3F);
+
+	uint32_t unpack = 0;
+
+	// shift one byte at a time into the unpack word, starting
+	// with the lowest byte.
+	for (size_t ipos = 0; ipos < 3; ++ipos) {
+		unpack = unpack << 8;
+		unpack |= (uint32_t)(compressed[ipos]);
+	}
+
+	// take 6-bit chunks off the unpack word, starting with the
+	// highest byte (end of data).
+	for (size_t opos = 0; opos < 4; ++opos) {
+		uint8_t b = (uint8_t)(unpack & LOWER6);
+		uncompressed[3 - opos] = (char)(b + SPACE);
+		unpack = unpack >> 6;
+	}
+}
+
+bool packed6_from_str(const char* str, Packed6* packed) {
+	const char* s = str ? str : "";
+
+	return packed6_from_str_slice(s, strnlen(s, PACKED6_MAX+1), packed);
+}
+
+bool packed6_from_str_slice(const char* str, size_t len, Packed6* packed) {
+	const char* s = str ? str : "";
+
+	bool ok = true;
+
+	// ensure input is exactly 8 characters
+	if (len > PACKED6_MAX) {
+		// truncate
+		ok = false;
+		len = PACKED6_MAX;
+	}
+	char work[9] = "";
+	snprintf(work, sizeof(work), "%-8.*s", (int)len, s);
+
+	ok &= compress_four_to_three(&work[0], &packed->b[0]);
+	ok &= compress_four_to_three(&work[4], &packed->b[3]);
+
+	return ok;
+}
+
+void packed6_from_bytes(const uint8_t bytes[PACKED6_SIZE], Packed6* packed)
+{
+	memcpy(&packed->b[0], bytes, sizeof(packed->b));
+}
+
+bool packed6_to_str(const Packed6* packed, char* out, size_t outsize) {
+	if (outsize < PACKED6_MAX + 1) {
+		if (outsize >= 1) {
+			out[0] = '\0';
+		}
+		return false;
+	}
+
+	decompress_three_to_four(&packed->b[0], &out[0]);
+	decompress_three_to_four(&packed->b[3], &out[4]);
+	out[PACKED6_MAX] = '\0';
+	return true;
+}
+
+void packed6_to_fixed_str(const Packed6* packed, char out[PACKED6_MAX + 1]) {
+	decompress_three_to_four(&packed->b[0], &out[0]);
+	decompress_three_to_four(&packed->b[3], &out[4]);
+	out[PACKED6_MAX] = '\0';
+}

--- a/src/common/Packed6.h
+++ b/src/common/Packed6.h
@@ -1,0 +1,122 @@
+#ifndef ARDOP_COMMON_PACKED6_H_
+#define ARDOP_COMMON_PACKED6_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "common/mustuse.h"
+
+/**
+ * @def PACKED6_SIZE
+ * @brief Number of compressed bytes in a Packed6
+ */
+#define PACKED6_SIZE 6
+
+/**
+ * @def PACKED6_MAX
+ * @brief Maximum uncompressed ASCII characters in a Packed6
+ */
+#define PACKED6_MAX 8
+
+/**
+ * @brief Compressed ASCII bytes (fits 8 characters in 6 bytes)
+ *
+ * This type is guaranteed to be cast-compatible with `uint8_t*`.
+ * It represents 8 ASCII characters in the range 32 (space) to
+ * 95 (underscore). This does *not* include lowercase letters,
+ * which cannot be represented in this encoding.
+ */
+typedef struct {
+	uint8_t b[PACKED6_SIZE];
+} Packed6;
+
+/**
+ * @brief Compress to eight characters from `str`
+ *
+ * Compresses up to eight ASCII characters in six bytes. If
+ * fewer than eight characters are provided, the remaining
+ * characters are padded with spaces (ASCII 32).
+ *
+ * Lowercase letters are silently converted to uppercase.
+ * Other invalid characters are replaced with spaces and will
+ * return an error.
+ *
+ * @param[in]  str      Null-terminated C string
+ * @param[out] packed   Packed representation of `str`
+ *
+ * @return true if the entire input was compressed into
+ * `packed` or false if it was not.
+ */
+ARDOP_MUSTUSE bool packed6_from_str(const char* str, Packed6* packed);
+
+/**
+ * @brief Compress to eight characters from `str`
+ *
+ * Compresses up to `len` ASCII characters, `len <= 8`,
+ * in six bytes. If fewer than eight characters are provided,
+ * the remaining characters are padded with spaces (ASCII 32).
+ *
+ * Lowercase letters are silently converted to uppercase.
+ * Other invalid characters are replaced with spaces and will
+ * return an error.
+ *
+ * @param[in]  str      C string (NUL termination optional)
+ * @param[in]  len      Number of characters in `str`, per `strlen()`
+ * @param[out] packed   Packed representation of `str`
+ *
+ * @return true if the entire input was compressed into
+ * `packed` or false if it was not.
+ */
+ARDOP_MUSTUSE bool packed6_from_str_slice(
+	const char* str, size_t len, Packed6* packed);
+
+/**
+ * @brief Construct from packed bytes
+ *
+ * Creates a Packed6 from the given compressed `bytes`.
+ *
+ * @param[in]  bytes    Packed bytes. This method requires
+ *                      *exactly* six bytes from `bytes`.
+ * @param[out] packed   A Packed6 which is ready for unpacking
+ */
+void packed6_from_bytes(const uint8_t bytes[PACKED6_SIZE], Packed6* packed);
+
+/**
+ * @brief Decompress a Packed6 to a C string
+ *
+ * Decompress the `packed` bytes into the specified C string,
+ * which must have a capacity of `outsize` bytes.
+ *
+ * @param[in]  packed   Packed bytes
+ * @param[out] out      Destination C string buffer
+ * @param[out] outsize  Capacity of `out` in bytes, per `sizeof()`
+ *
+ * @return true if the entire input was uncompressed into `out`
+ * or false if it was not. `out` will always be NUL-terminated
+ * if `size > 0`.
+ */
+ARDOP_MUSTUSE bool packed6_to_str(
+	const Packed6* packed,
+	char* out,
+	size_t outsize
+);
+
+/**
+ * @brief Decompress a Packed6 to a fixed C string
+ *
+ * Decompress the `packed` bytes into the specified C string
+ * that is at least 9 bytes in capacity. This method requires
+ * a string of known size at compile time. Unlike
+ * \ref packed6_to_fixed_str(), this method always succeeds.
+ *
+ * @param[in]  packed   Packed bytes
+ * @param[out] out      Destination C string buffer. The
+ *             output is always NUL-terminated.
+ */
+void packed6_to_fixed_str(
+	const Packed6* packed,
+	char out[PACKED6_MAX + 1]
+);
+
+#endif /* ARDOP_COMMON_PACKED6_H_ */

--- a/src/common/ardopcommon.h
+++ b/src/common/ardopcommon.h
@@ -194,7 +194,6 @@ extern void Generate50BaudTwoToneLeaderTemplate();
 extern BOOL blnDISCRepeating;
 
 void DeCompressCallsign(const char * bytCallsign, char * returned, size_t returnedlen);
-void DeCompressGridSquare(char * bytGS, char * returned);
 
 int RSEncode(UCHAR * bytToRS, UCHAR * bytRSEncoded, int MaxErr, int Len);
 BOOL RSDecode(UCHAR * bytRcv, int Length, int CheckLen, BOOL * blnRSOK);
@@ -331,7 +330,7 @@ extern struct SEM Semaphore;
 
 
 // Config Params
-extern char GridSquare[9];
+extern Locator GridSquare;
 extern char Callsign[CALL_BUF_SIZE];
 extern BOOL wantCWID;
 extern BOOL CWOnOff;

--- a/test/ardop/test_Locator.c
+++ b/test/ardop/test_Locator.c
@@ -1,0 +1,222 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <string.h>
+#include <cmocka.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "setup.h"
+
+#include "common/Locator.h"
+
+static void test_default_locator_bytes(void **state) {
+	(void)state; /* unused */
+
+	// calculate byte sequence used for invalid grid square
+	Packed6 nogs;
+	assert_true(packed6_from_str("NO GS", &nogs));
+
+	// ensure this is the default wireline representation
+	const Packed6* b = locator_as_bytes(NULL);
+	assert_memory_equal(&nogs, b, sizeof(Packed6));
+
+	// and for unset grid squares, too
+	Locator empty;
+	locator_init(&empty);
+	assert_false(locator_is_populated(&empty));
+	b = locator_as_bytes(&empty);
+	assert_memory_equal(&nogs, b, sizeof(Packed6));
+}
+
+/* test reading grid squares from strings */
+static void test_locator_from_str(void **state)
+{
+	(void)state; /* unused */
+
+	const static Packed6 PZERO = {{
+		0, 0, 0, 0, 0, 0
+	}};
+
+	Locator loc;
+
+	locator_init(&loc);
+	assert_false(locator_is_populated(&loc));
+
+	// the default locator has wireline memory of all zeros
+	assert_memory_equal(&loc.wire, &PZERO, sizeof(loc.wire));
+
+	// grid 0
+	assert_int_equal(LOCATOR_OK, locator_from_str("", &loc));
+	assert_string_equal(loc.grid, "");
+	assert_false(locator_is_populated(&loc));
+	assert_memory_equal(&loc.wire, &PZERO, sizeof(loc.wire));
+
+	// grid 2
+	assert_int_equal(LOCATOR_OK, locator_from_str("ar", &loc));
+	assert_true(locator_is_populated(&loc));
+	assert_string_equal(loc.grid, "AR");
+
+	// grid 4
+	assert_int_equal(LOCATOR_OK, locator_from_str("BL11", &loc));
+	assert_true(locator_is_populated(&loc));
+	assert_string_equal(loc.grid, "BL11");
+
+	// grid 6
+	assert_int_equal(LOCATOR_OK, locator_from_str("BL11bh", &loc));
+	assert_true(locator_is_populated(&loc));
+	assert_string_equal(loc.grid, "BL11bh");
+
+	// grid 8
+	assert_int_equal(LOCATOR_OK, locator_from_str("ar11ax16", &loc));
+	assert_true(locator_is_populated(&loc));
+	assert_string_equal(loc.grid, "AR11ax16");
+}
+
+static void test_locator_reject_toolong(void** state) {
+	Locator loc;
+
+	assert_int_equal(LOCATOR_ERR_TOOLONG, locator_from_str("BL11BH16KK", &loc));
+	assert_false(locator_is_populated(&loc));
+}
+
+static void test_locator_reject_oddlength(void** state) {
+	Locator loc;
+
+	assert_int_equal(LOCATOR_ERR_FMT_LENGTH, locator_from_str("B", &loc));
+	assert_false(locator_is_populated(&loc));
+
+	assert_int_equal(LOCATOR_ERR_FMT_LENGTH, locator_from_str("BL1", &loc));
+	assert_false(locator_is_populated(&loc));
+
+	assert_int_equal(LOCATOR_ERR_FMT_LENGTH, locator_from_str("BL11B", &loc));
+	assert_false(locator_is_populated(&loc));
+
+	assert_int_equal(LOCATOR_ERR_FMT_LENGTH, locator_from_str("BL11BH1", &loc));
+	assert_false(locator_is_populated(&loc));
+}
+
+static void test_locator_reject_badrange(void** state) {
+	Locator loc;
+
+	// letter out of range
+	assert_int_equal(LOCATOR_ERR_FMT_FIELD, locator_from_str("BS", &loc));
+	assert_false(locator_is_populated(&loc));
+	assert_int_equal(LOCATOR_ERR_FMT_FIELD, locator_from_str("SB", &loc));
+	assert_false(locator_is_populated(&loc));
+	assert_int_equal(LOCATOR_ERR_FMT_SUBSQUARE, locator_from_str("AA11AY", &loc));
+	assert_false(locator_is_populated(&loc));
+	assert_int_equal(LOCATOR_ERR_FMT_SUBSQUARE, locator_from_str("AA11YA", &loc));
+	assert_false(locator_is_populated(&loc));
+
+	// letter out of range (lowercase)
+	assert_int_equal(LOCATOR_ERR_FMT_FIELD, locator_from_str("sb", &loc));
+	assert_false(locator_is_populated(&loc));
+	assert_int_equal(LOCATOR_ERR_FMT_FIELD, locator_from_str("bs", &loc));
+	assert_false(locator_is_populated(&loc));
+	assert_int_equal(LOCATOR_ERR_FMT_SUBSQUARE, locator_from_str("aa11ay", &loc));
+	assert_false(locator_is_populated(&loc));
+	assert_int_equal(LOCATOR_ERR_FMT_SUBSQUARE, locator_from_str("aa11ya", &loc));
+	assert_false(locator_is_populated(&loc));
+
+	// letter when want number
+	assert_int_equal(LOCATOR_ERR_FMT_SQUARE, locator_from_str("BL1A", &loc));
+	assert_false(locator_is_populated(&loc));
+
+	// symbol when want number
+	assert_int_equal(LOCATOR_ERR_FMT_SQUARE, locator_from_str("BL1/", &loc));
+	assert_false(locator_is_populated(&loc));
+
+	// number when want letter
+	assert_int_equal(LOCATOR_ERR_FMT_FIELD, locator_from_str("A1", &loc));
+	assert_false(locator_is_populated(&loc));
+
+	// bad extended square
+	assert_int_equal(LOCATOR_ERR_FMT_EXTSQUARE, locator_from_str("AA11AAzz", &loc));
+	assert_false(locator_is_populated(&loc));
+}
+
+// there are several wire sequences for the "unpopulated" grid
+// square, and they should all be silently accepted as "no grid."
+//
+// one of these includes legacy ARDOPC's packed-6 encoding
+// of "`No GS`." The astute will note that this sequence used
+// a lowercase `o`. The legacy encoder did not encode this
+// correctly.
+static void test_locator_accept_unpopulated(void** state) {
+	const static Packed6 EMPTY = {{
+		0, 0, 0, 0, 0, 0
+	}};
+
+	const static Packed6 NOGS_1 = {{
+		0xbc, 0xf0, 0x27, 0xcc, 0x00, 0x00
+	}};
+
+	const static Packed6 NOGS_2 = {{
+		0xba, 0xf0, 0x27, 0xcc, 0x00, 0x00
+	}};
+
+	Locator loc;
+
+	assert_int_equal(LOCATOR_OK, locator_from_bytes(EMPTY.b, &loc));
+	assert_false(locator_is_populated(&loc));
+	assert_memory_equal(&loc.wire, &EMPTY, sizeof(loc.wire));
+
+	assert_int_equal(LOCATOR_OK, locator_from_bytes(NOGS_1.b, &loc));
+	assert_false(locator_is_populated(&loc));
+	assert_memory_equal(&loc.wire, &EMPTY, sizeof(loc.wire));
+
+	assert_int_equal(LOCATOR_OK, locator_from_bytes(NOGS_2.b, &loc));
+	assert_false(locator_is_populated(&loc));
+	assert_memory_equal(&loc.wire, &EMPTY, sizeof(loc.wire));
+}
+
+static void test_locator_from_bytes(void** state) {
+	const static char* TESTGRID[] = {
+		"AA",
+		"BL11",
+		"BH16kk",
+		"BH16kk00",
+	};
+
+	Locator out;
+	Locator inp;
+	for (size_t gr = 0; gr < sizeof(TESTGRID)/sizeof(TESTGRID[0]); ++gr) {
+		// test roundtrip out→in
+		assert_int_equal(LOCATOR_OK, locator_from_str(TESTGRID[gr], &out));
+		assert_int_equal(
+			LOCATOR_OK,
+			locator_from_bytes((const uint8_t*)locator_as_bytes(&out), &inp)
+		);
+
+		// data should be identical
+		assert_memory_equal(&inp, &out, sizeof(inp));
+	}
+}
+
+static void test_locator_strerror(void** state) {
+	(void)state; /* unused */
+
+	assert_string_equal("unknown error", locator_strerror(0));
+	assert_string_equal("unknown error", locator_strerror(LOCATOR_ERR_MAX_));
+	assert_string_equal("unknown error", locator_strerror(LOCATOR_ERR_MAX_ + 1));
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_default_locator_bytes),
+		cmocka_unit_test(test_locator_from_str),
+		cmocka_unit_test(test_locator_reject_toolong),
+		cmocka_unit_test(test_locator_reject_oddlength),
+		cmocka_unit_test(test_locator_reject_badrange),
+		cmocka_unit_test(test_locator_accept_unpopulated),
+		cmocka_unit_test(test_locator_from_bytes),
+		cmocka_unit_test(test_locator_strerror),
+	};
+
+	ardop_test_setup();
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}

--- a/test/ardop/test_Packed6.c
+++ b/test/ardop/test_Packed6.c
@@ -1,0 +1,92 @@
+#include <stdarg.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <setjmp.h>
+#include <string.h>
+#include <cmocka.h>
+
+#include "setup.h"
+
+#include "common/Packed6.h"
+
+/*
+ * Check that C string `inp` compresses and decompresses as
+ * `expect`. The `expect` output will always be exactly 8 characters,
+ * with any unused characters right-padded with spaces (ASCII 32).
+ *
+ * For cases where the compression should not succeed, set
+ * `succeed` to false.
+ */
+static void assert_6bit_inout(const char *inp, const char *expect, bool succeed)
+{
+	Packed6 compressed;
+	char out[9];
+
+	if (succeed)
+	{
+		assert_true(packed6_from_str(inp, &compressed));
+		assert_true(packed6_to_str(&compressed, out, sizeof(out)));
+		assert_string_equal(out, expect);
+	}
+	else
+	{
+		assert_false(packed6_from_str(inp, &compressed));
+		assert_true(packed6_to_str(&compressed, out, sizeof(out)));
+		assert_string_equal(out, expect);
+	}
+}
+
+/* test string-packing compression and decompression */
+static void test_ascii_6bit(void **state)
+{
+	(void)state; /* unused */
+
+	assert_6bit_inout("        ", "        ", true);
+	assert_6bit_inout("AZ09-_  ", "AZ09-_  ", true);
+	assert_6bit_inout("A      Z", "A      Z", true);
+	assert_6bit_inout("HI\0\0\0\0\0U", "HI      ", true);
+	assert_6bit_inout("abcxyz  ", "ABCXYZ  ", true);
+
+	// empty input → spaces
+	assert_6bit_inout("", "        ", true);
+	assert_6bit_inout(NULL, "        ", true);
+
+	// strings which are too long are truncated
+	assert_6bit_inout("TOOLONGSTRING", "TOOLONGS", false);
+
+	// invalid characters truncate
+	assert_6bit_inout("FAIL~D", "FAIL D  ", false);
+	assert_6bit_inout("{NO}", " NO     ", false);
+}
+
+/* test Packed6 construction from bytes */
+static void test_packed6_from_bytes(void** state)
+{
+	(void)state; /* unused */
+
+	Packed6 pkout;
+	Packed6 pkin;
+
+	assert_true(packed6_from_str("ABCXYZ", &pkout));
+	packed6_from_bytes(pkout.b, &pkin);
+	assert_memory_equal(&pkout, &pkin, sizeof(Packed6));
+
+	char out[9] = {0};
+	assert_true(packed6_to_str(&pkin, out, sizeof(out)));
+	assert_string_equal("ABCXYZ  ", out);
+
+	memset(out, 0, sizeof(out));
+	packed6_to_fixed_str(&pkin, out);
+	assert_string_equal("ABCXYZ  ", out);
+}
+
+int main(void)
+{
+	const struct CMUnitTest tests[] = {
+		cmocka_unit_test(test_ascii_6bit),
+		cmocka_unit_test(test_packed6_from_bytes)
+	};
+
+	ardop_test_setup();
+	return cmocka_run_group_tests(tests, NULL, NULL);
+}


### PR DESCRIPTION
This PR replaces the string-based Maidenhead Grid Square processing with a new `Locator` object. The object representation ensures that:

* only valid grid squares may exist and be transmitted
* the ARDOP wireline representation is always available for immediate use

## User-Visible Changes

* Some invalid `GRIDSQUARE` inputs which were previously accepted are now rejected as invalid.
* The `FAULT` message for invalid `GRIDSQUARE` has additional detail.
* Invalid grid squares received in ID Frames are no longer passed to the host. The rest of the ID Frame remains valid and is passed.

I personally consider these changes API-preserving, since:

* Previous acceptance of invalid grid squares should be considered a bug
* The content of FAULT messages is not specified by the spec

## Known Issue: NO GS encoding

Previous versions of ardopcf would transmit an encoded "`No GS`" byte sequence when the TNC's `GRIDSQUARE` was unset. This was probably an effort to avoid sending long runs of zeros, which in some modulation schemes tends to cause sync drift. Prior to 9d50e2a9ddc554e5a61f39f0aef59051563adb45, we would transmit this Packed6:

```c
{0xbc, 0xf0, 0x27, 0xcc, 0x00, 0x00}
```

This is because we compressed the invalid Packed6 string "`No GS`" with a lowercase character.

After 9d50e2a9ddc554e5a61f39f0aef59051563adb45, we correctly uppercase the inputs to the compressor. We now send:

```c
{0xba, 0xf0, 0x27, 0xcc, 0x00, 0x00}
// ^^ changed
```

which is the result of compressing the *uppercased* version, "`NO GS`."

I do not know if the change affects other ARDOP implementations.

The new `Locator` object retains the current behavior. Both byte sequences are silently accepted as meaning "no grid square." We also accept a sequence of zeros as "no grid square."

## Known Issue: No Way to Unset Grid Square

The host interface does not expose a way to **unset** the grid square.

* `GRIDSQUARE` just queries for the current grid square
* `GRIDSQUARE AA11bb22` sets the grid square and will not *un*set it if invalid. This matches the current behavior of this command in `develop`.

It may not be worth implementing a way to clear the GRIDSQUARE, but if it is we should make a new issue for that.

## Review Info

The `Packed6` object is very similar to #79, but it uses more advanced array declaration syntax to check the size of the input at compile-time.

```c
void packed6_to_fixed_str(
	const Packed6* packed,
	char out[PACKED6_MAX + 1]
)
```

This makes the decompress operation infallible, which is nice. See diffs:

```bash
git diff 514796d50ebcd8cade23703c691985e3617bfdb2 -- src/common/Packed6.*
```

This will hopefully address the remaining review comments on `Packed6` from #79.

I am working this before `StationId` (#79) because it is more straightforward and less impactful than replacing station IDs / callsigns, which are ubiquitous and have a lot of potential for bad interactions. I want to shrink #79 down so it can focus on the integration.