### PR TITLE
Post PR #79 Adjustments

### DIFF
--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -196,7 +196,7 @@ enum _ProtocolMode ProtocolMode = FEC;
 
 extern BOOL blnEnbARQRpt;
 extern BOOL blnDISCRepeating;
-extern StationId ARQStationRemote;  // current connection peer callsign
+extern StationId ARQStationRemote;  // current connection remote callsign
 extern StationId ARQStationLocal;   // current connection local callsign
 extern StationId ARQStationFinalId; // post-session local IDF to send
 extern int dttTimeoutTrip;

--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -1343,7 +1343,7 @@ int EncodeARQConRequest(const StationId* mycall, const StationId* target, enum _
 {
 	// Encodes a 4FSK 200 Hz BW Connect Request frame ( ~ 1950 ms with default leader/trailer)
 
-	if (!stationid_ok(mycall) || stationid_is_cq(mycall)) {
+	if (!stationid_ok(mycall)) {
 		ZF_LOGE("Unable to send connection request: MYCALL is unset");
 		return 0;
 	}
@@ -1403,7 +1403,7 @@ int EncodePing(const StationId* mycall, const StationId* target, UCHAR * bytRetu
 
 	UCHAR * bytToRS= &bytReturn[2];
 
-	if (!stationid_ok(mycall) || stationid_is_cq(mycall)) {
+	if (!stationid_ok(mycall)) {
 		ZF_LOGE("Unable to send ping: MYCALL is unset");
 		return 0;
 	}
@@ -1440,7 +1440,7 @@ int Encode4FSKIDFrame(const StationId* callsign, const Locator* square, unsigned
 
 	UCHAR * bytToRS= &bytreturn[2];
 
-	if (!stationid_ok(callsign) || stationid_is_cq(callsign))
+	if (!stationid_ok(callsign))
 	{
 		ZF_LOGE("Unable to send ID frame: MYCALL is unset");
 		return 0;

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -87,7 +87,7 @@ const char ARQSubStates[10][11] = {
 extern StationId LastDecodedStationCaller;
 extern StationId LastDecodedStationTarget;
 
-StationId ARQStationRemote;  // current connection peer callsign
+StationId ARQStationRemote;  // current connection remote callsign
 StationId ARQStationLocal;   // current connection local callsign
 StationId ARQStationFinalId; // post-session local IDF to send
 

--- a/src/common/FEC.c
+++ b/src/common/FEC.c
@@ -80,7 +80,7 @@ BOOL StartFEC(UCHAR * bytData, int Len, char * strDataMode, int intRepeats, BOOL
 
 	// check call sign
 
-	if (!stationid_ok(&Callsign) || stationid_is_cq(&Callsign))
+	if (!stationid_ok(&Callsign))
 	{
 		// Logs.Exception("[ARDOPprotocol.StartFEC] Invalid call sign: " & MCB.Callsign)
 		return FALSE;

--- a/src/common/HostInterface.c
+++ b/src/common/HostInterface.c
@@ -926,16 +926,6 @@ void ProcessCommandFromHost(char * strCMD)
 			goto cmddone;
 		}
 
-		for (size_t i = 0; i < AuxCallsLength; ++i) {
-			if (stationid_is_cq(&AuxCalls[i])) {
-				snprintf(strFault, sizeof(strFault), "Syntax Err: at callsign %lu: a CQ callsign is not permitted", i);
-				/* The TNC protocol requires that invalid input
-				 * completely clears the MYAUX array */
-				AuxCallsLength = 0;
-				break;
-			}
-		}
-
 		stationid_array_to_str(
 			AuxCalls,
 			AuxCallsLength,
@@ -963,8 +953,6 @@ void ProcessCommandFromHost(char * strCMD)
 		station_id_err e = stationid_from_str(ptrParams, &new_mycall);
 		if (e) {
 			snprintf(strFault, sizeof(strFault), "Syntax Err: %s %s: %s", strCMD, ptrParams, stationid_strerror(e));
-		} else if (stationid_is_cq(&new_mycall)) {
-			snprintf(strFault, sizeof(strFault), "Syntax Err: %s %s: a CQ callsign is not permitted", strCMD, ptrParams);
 		} else {
 			memcpy(&Callsign, &new_mycall, sizeof(Callsign));
 			wg_send_mycall(0, Callsign.str);

--- a/src/common/HostInterface.c
+++ b/src/common/HostInterface.c
@@ -988,16 +988,11 @@ void ProcessCommandFromHost(char * strCMD)
 			goto cmddone;
 		}
 
-		switch (ProtocolMode) {
-		case RXO:
+		if (ProtocolMode == RXO) {
 			snprintf(strFault, sizeof(strFault), "Not from mode RXO");
-			break;
-		default:
-			if (ProtocolState != DISC)
-			{
-				snprintf(strFault, sizeof(strFault), "No PING from state %s", ARDOPStates[ProtocolState]);
-				goto cmddone;
-			}
+		} else if (ProtocolState != DISC) {
+			snprintf(strFault, sizeof(strFault), "No PING from state %s", ARDOPStates[ProtocolState]);
+			goto cmddone;
 		}
 
 		PingCount = (int)nattempts;

--- a/src/common/Locator.c
+++ b/src/common/Locator.c
@@ -5,6 +5,8 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+#include "common/log.h"
+
 // Legacy ARDOPC used to transmit "No GS" in IDFRAMEs to indicate
 // that the grid square is unset. This is *not* valid as a
 // Packed6 since it was actually encoded with a lowercase "o."
@@ -108,37 +110,41 @@ static locator_err locator_uncompress(const Packed6* in, Locator* locator) {
 
 ARDOP_MUSTUSE locator_err
 locator_validate_grid(const Locator* locator) {
+	locator_err err = LOCATOR_OK;
 	size_t len = strnlen(locator->grid, sizeof(locator->grid));
 	if (len % 2 != 0) {
-		return LOCATOR_ERR_FMT_LENGTH;
-	}
-
-	for (size_t i = 0; i < len; ++i) {
-		switch (i/2) {
-			case 0:
-				// field A – R
-				if (! is_ascii_alpha_range(locator->grid[i], 'R'))
-					return LOCATOR_ERR_FMT_FIELD;
-				break;
-			case 1:
-				// square 0 – 9
-				if (! is_ascii_digit(locator->grid[i]))
-					return LOCATOR_ERR_FMT_SQUARE;
-				break;
-			case 2:
-				// subsquare A – X
-				if (! is_ascii_alpha_range(locator->grid[i], 'X'))
-					return LOCATOR_ERR_FMT_SUBSQUARE;
-				break;
-			default:
-				// extended square, 0 – 9
-				if (! is_ascii_digit(locator->grid[i]))
-					return LOCATOR_ERR_FMT_EXTSQUARE;
-				break;
+		err = LOCATOR_ERR_FMT_LENGTH;
+	} else {
+		for (size_t i = 0; i < len; ++i) {
+			switch (i/2) {
+				case 0:
+					// field A – R
+					if (! is_ascii_alpha_range(locator->grid[i], 'R'))
+						err = LOCATOR_ERR_FMT_FIELD;
+					break;
+				case 1:
+					// square 0 – 9
+					if (! is_ascii_digit(locator->grid[i]))
+						err = LOCATOR_ERR_FMT_SQUARE;
+					break;
+				case 2:
+					// subsquare A – X
+					if (! is_ascii_alpha_range(locator->grid[i], 'X'))
+						err = LOCATOR_ERR_FMT_SUBSQUARE;
+					break;
+				default:
+					// extended square, 0 – 9
+					if (! is_ascii_digit(locator->grid[i]))
+						err = LOCATOR_ERR_FMT_EXTSQUARE;
+					break;
+			}
 		}
 	}
 
-	return LOCATOR_OK;
+	if (err != LOCATOR_OK)
+		ZF_LOGD("Grid square=\"%s\" is invalid: %s", locator->grid, locator_strerror(err));
+
+	return err;
 }
 
 void locator_init(Locator* locator) {

--- a/src/common/Locator.c
+++ b/src/common/Locator.c
@@ -11,7 +11,7 @@
 //
 // To support this, we quietly accept any of the following
 // byte sequences as an unset grid square.
-const static Packed6 LOCATOR_NOGS[] = {
+static const Packed6 LOCATOR_NOGS[] = {
 	{{0xbc, 0xf0, 0x27, 0xcc, 0x00, 0x00}},
 	{{0xba, 0xf0, 0x27, 0xcc, 0x00, 0x00}},
 };
@@ -211,7 +211,7 @@ bool locator_is_populated(const Locator* locator) {
 }
 
 const char* locator_strerror(locator_err err) {
-	const static char* MSGS[] = {
+	static const char* MSGS[] = {
 		"unknown error",
 		"length exceeded",
 		"locator must be 2, 4, 6, or 8 characters",

--- a/src/common/StationId.c
+++ b/src/common/StationId.c
@@ -13,9 +13,6 @@
 // maximum number of characters in a callsign
 #define CALLSIGN_MAX 7
 
-// broadcast message directed at all stations
-#define CQ "CQ"
-
 /**
  * Validate callsign
  *
@@ -236,11 +233,6 @@ void stationid_init(StationId* station) {
 	station->ssid[0] = '0';
 }
 
-void stationid_make_cq(StationId* station) {
-	station_id_err ignore = stationid_from_str_slice(CQ, sizeof(CQ), station);
-	(void)ignore; /* unused */
-}
-
 station_id_err stationid_from_str(const char* str, StationId* station) {
 	const char* inp = str ? str : "";
 	size_t len = strlen(inp);
@@ -410,10 +402,6 @@ bool stationid_ok(const StationId* station) {
 		ok |= station->wire.b[i];
 	}
 	return ok;
-}
-
-bool stationid_is_cq(const StationId* station) {
-	return 0 == strncmp(CQ, station->call, sizeof(station->call));
 }
 
 bool stationid_eq(const StationId* a, const StationId* b) {

--- a/src/common/StationId.c
+++ b/src/common/StationId.c
@@ -423,7 +423,7 @@ bool stationid_eq(const StationId* a, const StationId* b) {
 }
 
 const char* stationid_strerror(station_id_err err) {
-	const static char* MSGS[] = {
+	static const char* MSGS[] = {
 		"unknown error",
 		"maximum length exceeded or unsupported format",
 		"callsign uses unsupported characters",

--- a/src/common/StationId.h
+++ b/src/common/StationId.h
@@ -141,17 +141,6 @@ typedef struct {
 void stationid_init(StationId* station);
 
 /**
- * @brief Make a CQ call
- *
- * Construct a station ID that represents a broadcast message to
- * all stations. CQ calls are not valid as source callsigns and
- * should never be used in IDFRAMEs.
- *
- * @param[in] station    Station ID to populate.
- */
-void stationid_make_cq(StationId* station);
-
-/**
  * @brief Create a station ID from a string
  *
  * Accepts a string of the form "`N0CALL-15`" and parses it into a
@@ -334,17 +323,6 @@ bool stationid_array_to_str(
  * if otherwise.
  */
 bool stationid_ok(const StationId* station);
-
-/**
- * @brief True if the station ID is a "CQ" broadcast
- *
- * Messages directed at "`CQ`" with any SSID are intended for
- * all stations. A station ID of "`CQ`" is not valid for use
- * as a source callsign or for use in IDFRAMEs.
- *
- * @return true if the station ID is a CQ call
- */
-bool stationid_is_cq(const StationId* station);
 
 /**
  * @brief Equality test

--- a/src/common/Webgui.c
+++ b/src/common/Webgui.c
@@ -29,7 +29,7 @@ extern BOOL NeedTwoToneTest;
 extern BOOL NeedID;
 extern BOOL WG_DevMode;
 extern StationId Callsign;
-extern StationId ARQStationRemote;  // current connection peer callsign
+extern StationId ARQStationRemote;  // current connection remote callsign
 extern float wS1;
 int ExtractARQBandwidth();
 void ProcessCommandFromHost(char * strCMD);

--- a/src/common/log.c
+++ b/src/common/log.c
@@ -228,7 +228,7 @@ int ardop_log_get_level_file() {
 }
 
 void ardop_log_session_header(
-	const char* peer_callsign,
+	const char* remote_callsign,
 	const struct timespec* now,
 	const time_t duration
 )
@@ -250,7 +250,7 @@ void ardop_log_session_header(
 		"%s,%09ld+00:00\n************************* ARQ session stats with %s  %d minutes ****************************\n",
 		datefmt,
 		now->tv_nsec,
-		peer_callsign,
+		remote_callsign,
 		(int)duration
 	);
 }

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -236,7 +236,7 @@ int ardop_log_get_level_file();
  * This method writes the banner that occurs at the start of
  * every record.
  *
- * @param[in] peer_callsign  The callsign of the remote station
+ * @param[in] remote_callsign  The callsign of the remote station
  * @param[in] now  UNIX time as of session end
  * @param[in] duration  The duration of the session, as a UNIX
  *            time in seconds
@@ -245,7 +245,7 @@ int ardop_log_get_level_file();
  * @see ardop_log_session_footer
  */
 void ardop_log_session_header(
-	const char* peer_callsign,
+	const char* remote_callsign,
 	const struct timespec* now,
 	const time_t duration
 );

--- a/src/common/txframe.c
+++ b/src/common/txframe.c
@@ -279,7 +279,7 @@ int txframe(char * frameParams) {
 			if (e) {
 				ZF_LOGE(
 					"Invalid mycall \"%s\" for TXFRAME ConReq: %s",
-					params[2],
+					params[3],
 					stationid_strerror(e));
 				return 1;
 			}
@@ -440,7 +440,7 @@ int txframe(char * frameParams) {
 				"TXFRAME Ping requires an explicit target.");
 			return (1);
 		}
-		if (paramcount > 3 && strcmp(params[2], "_") != 0) {
+		if (paramcount > 3 && strcmp(params[3], "_") != 0) {
 			station_id_err e = stationid_from_str(params[3], &mycall);
 			if (e) {
 				ZF_LOGE(

--- a/test/ardop/test_Locator.c
+++ b/test/ardop/test_Locator.c
@@ -36,7 +36,7 @@ static void test_locator_from_str(void **state)
 {
 	(void)state; /* unused */
 
-	const static Packed6 PZERO = {{
+	static const Packed6 PZERO = {{
 		0, 0, 0, 0, 0, 0
 	}};
 
@@ -146,15 +146,15 @@ static void test_locator_reject_badrange(void** state) {
 // a lowercase `o`. The legacy encoder did not encode this
 // correctly.
 static void test_locator_accept_unpopulated(void** state) {
-	const static Packed6 EMPTY = {{
+	static const Packed6 EMPTY = {{
 		0, 0, 0, 0, 0, 0
 	}};
 
-	const static Packed6 NOGS_1 = {{
+	static const Packed6 NOGS_1 = {{
 		0xbc, 0xf0, 0x27, 0xcc, 0x00, 0x00
 	}};
 
-	const static Packed6 NOGS_2 = {{
+	static const Packed6 NOGS_2 = {{
 		0xba, 0xf0, 0x27, 0xcc, 0x00, 0x00
 	}};
 
@@ -174,7 +174,7 @@ static void test_locator_accept_unpopulated(void** state) {
 }
 
 static void test_locator_from_bytes(void** state) {
-	const static char* TESTGRID[] = {
+	static const char* TESTGRID[] = {
 		"AA",
 		"BL11",
 		"BH16kk",

--- a/test/ardop/test_log.c
+++ b/test/ardop/test_log.c
@@ -182,7 +182,7 @@ static void test_ardop_logfile_handle(void** state) {
 static void test_ardop_logfile_write(void** state) {
 	(void)state; /* unused */
 
-	const static char MSG[] = "x";
+	static const char MSG[] = "x";
 
 	ArdopLogFile uut;
 	ardop_logfile_init(&uut, "", "ARDOPDebug", ".log", 8515);
@@ -209,7 +209,7 @@ static void test_ardop_logfile_write(void** state) {
 }
 
 static void test_ardop_log_verbosity(void** state) {
-	const static int LEVELS[] = {
+	static const int LEVELS[] = {
 		ZF_LOG_VERBOSE,
 		ZF_LOG_DEBUG,
 		ZF_LOG_INFO,


### PR DESCRIPTION
A few adjustments to followup PR #79 which reworked the handling of station id callsigns.

In addition to some bugfixes and style/comment changes, this eliminates all code for special handling of CQ as a station id.  Prior code relating to CQ was of limited utility and use.  Current tests for valid callsigns allow any 2-character callsign.  So, CQ can still be used if desired.  A user should not use CQ for MYCALL or MYAUX, but using CQ is no worse than using any other illegal callsign.  So, special tests to prevent this are not needed.  No code exists or probably has existed to allow appropriate automatic response to a Connect Request to CQ.  See a related discussion of CQ at the ardop users group:
https://ardop.groups.io/g/users/topic/use_of_cq_with_ardop/108851759

This pull request also fixes a deficiency from PR #93 which reworked the handling of grid square locators.  This fix modifies locator_validate_grid() so that if an invalid grid is found, it is written to the debug log.  This may be useful for debugging purposes if a frame containing an invalid grid is decoded.