### PR TITLE
New INPUTNOISE host command adds AGWN to received audio.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ OBJS = \
 	src/common/gen-webgui.html.o \
 	src/common/gen-webgui.js.o \
 	src/common/Webgui.o \
+	src/common/noise.o \
 
 # Linux-only object files
 OBJS_LIN = \

--- a/src/common/ARDOPCommon.c
+++ b/src/common/ARDOPCommon.c
@@ -62,6 +62,9 @@ extern char HostPort[80];
 extern char CaptureDevice[80];
 extern char PlaybackDevice[80];
 
+extern short InputNoiseStdDev;
+void add_noise(short *samples, unsigned int nSamples, short stddev);
+
 int extraDelay = 0;  // Used for long delay paths eg Satellite
 int	intARQDefaultDlyMs = 240;
 int TrailerLength = 20;
@@ -596,6 +599,7 @@ int decode_wav()
 	ZF_LOGD("Reading %d 16-bit samples.", nSamples);
 	// Send blocksize silent samples to ProcessNewSamples() before start of WAV file data.
 	memset(samples, 0, sizeof(samples));
+	add_noise(samples, blocksize, InputNoiseStdDev);
 	ProcessNewSamples(samples, blocksize);
 	while (nSamples >= blocksize)
 	{
@@ -606,6 +610,7 @@ int decode_wav()
 			return 5;
 		}
 		WavNow += blocksize * 1000 / 12000;
+		add_noise(samples, blocksize, InputNoiseStdDev);
 		ProcessNewSamples(samples, blocksize);
 		nSamples -= blocksize;
 	}
@@ -616,6 +621,7 @@ int decode_wav()
 		return 6;
 	}
 	WavNow += nSamples * 1000 / 12000;
+	add_noise(samples, blocksize, InputNoiseStdDev);
 	ProcessNewSamples(samples, nSamples);
 	nSamples = 0;
 	// Send additional silent samples to ProcessNewSamples() after end of WAV file data.
@@ -623,6 +629,7 @@ int decode_wav()
 	memset(samples, 0, sizeof(samples));
 	for (int i=0; i<20; i++) {
 		WavNow += blocksize * 1000 / 12000;
+		add_noise(samples, blocksize, InputNoiseStdDev);
 		ProcessNewSamples(samples, blocksize);
 	}
 

--- a/src/common/HostInterface.c
+++ b/src/common/HostInterface.c
@@ -37,6 +37,7 @@ int wg_send_hostdatab(int cnum, char *prefix, unsigned char *data, int datalen);
 int wg_send_hostdatat(int cnum, char *prefix, unsigned char *data, int datalen);int wg_send_drivelevel(int cnum);
 
 extern BOOL NeedTwoToneTest;
+extern short InputNoiseStdDev;
 
 #ifndef WIN32
 
@@ -1479,6 +1480,21 @@ void ProcessCommandFromHost(char * strCMD)
 		goto cmddone;
 	}
 
+	// Set the standard deviation of AWGN to be added to 16-bit input audio.
+	// Set it to 0 for no noise.
+	if (strcmp(strCMD, "INPUTNOISE") == 0)
+	{
+		if (ptrParams == 0) {
+			sprintf(cmdReply, "%s %d", strCMD, InputNoiseStdDev);
+			SendReplyToHost(cmdReply);
+		} else {
+			// TODO: error checking of value
+			InputNoiseStdDev = atoi(ptrParams);
+			sprintf(cmdReply, "%s now %hd", strCMD, InputNoiseStdDev);
+			SendReplyToHost(cmdReply);
+		}
+		goto cmddone;
+	}
 
 	snprintf(strFault, sizeof(strFault), "CMD %s not recoginized", strCMD);
 

--- a/src/common/noise.c
+++ b/src/common/noise.c
@@ -1,0 +1,72 @@
+#include <math.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+short next_grand_s16 = 0;
+bool next_grand_s16_avail = false;
+
+// Recall that approximatelye 99.7% of values will fall within 3 standard
+// deviations of the mean, which is this case is 0.
+
+// Return a (signed) 16-bit integer with a gaussian distribution
+// about 0 and the specified stddev.  Recall that approximatelye 99.7% of
+// values will fall within 3 standard deviations of the mean, which is this
+// case is 0.
+// The algorithm used generates pairs of values.  The extra value is stored and
+// returned the next time grand_s16 is called.  Whenever the value to be used
+// for stddev is changed, the first result from grand_s16() should be discarded.
+// If the raw result is less than -32768 or greater than 32767, it is truncated
+// to fit within this range.
+short grand_s16(short stddev) {
+	if (next_grand_s16_avail) {
+		next_grand_s16_avail = false;
+		return next_grand_s16;
+	}
+	double s, u0, u1;
+	int value;
+	while (true) {
+		u0 = (double) rand() / RAND_MAX * 2.0 - 1.0;
+		u1 = (double) rand() / RAND_MAX * 2.0 - 1.0;
+		s = u0 * u0 + u1 * u1;
+		if (s < 1.0 && s > 0.0)
+			break;
+	}
+	s = sqrt(-2.0 * log(s) / s);
+
+	value = round(stddev * u0 * s);
+	if (value < -32768)
+		next_grand_s16 = -32768;
+	else if (value > 32767)
+		next_grand_s16 = 32767;
+	else
+		next_grand_s16 = (short) value;
+	next_grand_s16_avail = true;
+
+	value = round(stddev * u1 * s);
+	if (value < -32768)
+		return (short) -32768;
+	if (value > 32767)
+		return (short) 32767;
+	return (short) value;
+}
+
+
+void add_noise(short *samples, unsigned int nSamples, short stddev) {
+	if (stddev == 0)
+		return;
+
+	// In case stsddev has changed, discard the first value.
+	grand_s16(stddev);
+
+	short noise = 0;
+	for (unsigned i = 0; i < nSamples; i++) {
+		noise = grand_s16(stddev);
+		if (samples[i] + noise < -32769)
+			samples[i] = -32768;
+		else if (samples[i] + noise > 32767)
+			samples[i] = 32767;
+		else
+			samples[i] += noise;
+	}
+}

--- a/src/linux/ALSASound.c
+++ b/src/linux/ALSASound.c
@@ -52,6 +52,9 @@ int wg_send_pttled(int cnum, bool isOn);
 int wg_send_pixels(int cnum, unsigned char *data, size_t datalen);
 void WebguiPoll();
 
+void add_noise(short *samples, unsigned int nSamples, short stddev);
+short InputNoiseStdDev = 0;
+
 extern BOOL blnDISCRepeating;
 
 extern char * CM108Device;
@@ -1562,7 +1565,7 @@ int SoundCardRead(short * input, unsigned int nSamples)
 	{
 		for (n = 0; n < ret; n++)
 		{
-			*(input++) = samples[n];
+			memcpy(input, samples, nSamples*sizeof(short));
 		}
 	}
 	else
@@ -1574,9 +1577,11 @@ int SoundCardRead(short * input, unsigned int nSamples)
 
 		for (n = start; n < (ret * 2); n+=2)  // return alternate
 		{
-			*(input++) = samples[n];
+			input[n] = samples[n];
 		}
 	}
+
+	add_noise(input, nSamples, InputNoiseStdDev);
 
 	if (rxwf != NULL)
 	{
@@ -1588,7 +1593,7 @@ int SoundCardRead(short * input, unsigned int nSamples)
 			rxwf = NULL;
 		}
 		else
-			WriteWav(samples, ret, rxwf);
+			WriteWav(input, ret, rxwf);
 	}
 
 	return ret;

--- a/src/windows/Waveout.c
+++ b/src/windows/Waveout.c
@@ -100,6 +100,9 @@ WAVEHDR inheader[5] =
 WAVEOUTCAPS pwoc;
 WAVEINCAPS pwic;
 
+void add_noise(short *samples, unsigned int nSamples, short stddev);
+short InputNoiseStdDev = 0;
+
 int InitSound(BOOL Quiet);
 void HostPoll();
 void TCPHostPoll();
@@ -732,6 +735,8 @@ void PollReceivedSamples()
 	{
 		short * ptr = &inbuffer[inIndex][0];
 		int i;
+
+		add_noise(inbuffer[inIndex], ReceiveSize, InputNoiseStdDev);
 
 		for (i = 0; i < ReceiveSize; i++)
 		{


### PR DESCRIPTION
Add the new INPUTNOISE host command which takes an integer argument.  This argument sets the standard deviation of Gaussian white noise that is added to all incoming audio including audio from WAV files being decoded.  If the incoming audio plus the noise exceeds the capacity of the signed 16-bit integers used for raw audio samples, then clipping will occur.

This new command is not intended to be used or useful during normal operation of ardopcf.  Rather, it is another feature which is useful for diagnostic purposes.