### PR TITLE
Fec bugfixes

### DIFF
--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -61,6 +61,10 @@ const char* PlatformSignalAbbreviation(int signal);
 BOOL BusyDetect2(float * dblMag, int intStart, int intStop);
 BOOL IsPingToMe(const StationId* caller, const StationId* target);
 
+void ResetCarrierOk();
+void ResetAvgs();
+extern int LastDataFrameType;
+
 void WebguiInit();
 void WebguiPoll();
 int wg_send_fftdata(float *mags, int magsLen);
@@ -633,6 +637,11 @@ void setProtocolMode(char* strMode)
 		ProtocolMode = ARQ;
 		return;
 	}
+	// CLear MEM ARQ Stuff
+	ResetCarrierOk();
+	ResetAvgs();
+	LastDataFrameType = -1;
+
 	wg_send_protocolmode(0);
 }
 

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -54,7 +54,8 @@ int bytQDataInProcessLen = 0;  // Length of frame to send/last sent
 
 BOOL blnLastFrameSentData = FALSE;
 
-extern char CarrierOk[8];
+void ResetCarrierOk();
+void ResetAvgs();
 extern int LastDataFrameType;
 extern BOOL blnARQDisconnect;
 extern const short FrameSize[256];
@@ -1227,7 +1228,9 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				ARQState = IRSConAck;  // now connected
 
 				intLastARQDataFrameToHost = -1;  // precondition to an illegal frame type
-				memset(CarrierOk, 0, sizeof(CarrierOk));  // CLear MEM ARQ Stuff
+				// CLear MEM ARQ Stuff
+				ResetCarrierOk();
+				ResetAvgs();
 				LastDataFrameType = -1;
 
 				// latch the ConReq callsign pair from the decoder
@@ -1305,7 +1308,9 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 						ARQState = IRSConAck;  // now connected
 
 						intLastARQDataFrameToHost = -1;  // precondition to an illegal frame type
-						memset(CarrierOk, 0, sizeof(CarrierOk));  // CLear MEM ARQ Stuff
+						// CLear MEM ARQ Stuff
+						ResetCarrierOk();
+						ResetAvgs();
 						LastDataFrameType = -1;
 
 						intAvgQuality = 0;  // initialize avg quality
@@ -1758,7 +1763,9 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 			intLinkTurnovers += 1;
 			intLastARQDataFrameToHost = -1;  // precondition to an illegal frame type (insures the new IRS does not reject a frame)
-			memset(CarrierOk, 0, sizeof(CarrierOk));  // CLear MEM ARQ Stuff
+			// CLear MEM ARQ Stuff
+			ResetCarrierOk();
+			ResetAvgs();
 			LastDataFrameType = -1;
 			return;
 		}
@@ -1975,7 +1982,9 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 					intLinkTurnovers += 1;
 					intLastARQDataFrameToHost = -1;  // precondition to an illegal frame type (insures the new IRS does not reject a frame)
-					memset(CarrierOk, 0, sizeof(CarrierOk));  // CLear MEM ARQ Stuff
+					// CLear MEM ARQ Stuff
+					ResetCarrierOk();
+					ResetAvgs();
 					LastDataFrameType = intFrameType;
 				}
 				else
@@ -2111,7 +2120,9 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				ARQState = IRSfromISS;  // Substate IRSfromISS allows processing of Rule 3.5 later
 
 				intLinkTurnovers += 1;
-				memset(CarrierOk, 0, sizeof(CarrierOk));  // CLear MEM ARQ Stuff
+				// CLear MEM ARQ Stuff
+				ResetCarrierOk();
+				ResetAvgs();
 				LastDataFrameType = intFrameType;
 				intLastARQDataFrameToHost = -1;  // precondition to an illegal frame type (insures the new IRS does not reject a frame)
 				return;

--- a/src/common/FEC.c
+++ b/src/common/FEC.c
@@ -353,7 +353,7 @@ void ProcessRcvdFECDataFrame(int intFrameType, UCHAR * bytData, BOOL blnFrameDec
 		{
 			AddTagToDataAndSendToHost(bytFailedData, "ERR", bytFailedDataLength);
 			if (CommandTrace)
-				ZF_LOGI("[ARDOPprotocol.ProcessRcvdFECDataFrame] Pass failed frame ID %s to Host (%d bytes)", Name(intFrameType), bytFailedDataLength);
+				ZF_LOGI("[ARDOPprotocol.ProcessRcvdFECDataFrame] Pass failed frame ID %s to Host (%d bytes)", Name(intLastFailedFrameID), bytFailedDataLength);
 			bytFailedDataLength = 0;
 			intLastFailedFrameID = -1;
 		}
@@ -374,13 +374,10 @@ void ProcessRcvdFECDataFrame(int intFrameType, UCHAR * bytData, BOOL blnFrameDec
 		memset(intCarPhaseAvg, 0, sizeof(intCarPhaseAvg));
 		memset(intCarMagAvg, 0, sizeof(intCarMagAvg));
 
-		crcLastFECDataPassedToHost = GenCRC16(bytData, frameLen);
+		crcLastFECDataPassedToHost = CRC;
 		intLastFrameIDToHost = intFrameType;
-		if (intLastFailedFrameID == intFrameType)
-		{
-			bytFailedDataLength = 0;
-			intLastFailedFrameID = -1;
-		}
+		bytFailedDataLength = 0;
+		intLastFailedFrameID = -1;
 
 		if (CommandTrace)
 			ZF_LOGI("[ARDOPprotocol.ProcessRcvdFECDataFrame] Pass good data frame  ID %s to Host (%d bytes)", Name(intFrameType), frameLen);
@@ -393,11 +390,9 @@ void ProcessRcvdFECDataFrame(int intFrameType, UCHAR * bytData, BOOL blnFrameDec
 		{
 			AddTagToDataAndSendToHost(bytFailedData, "ERR", bytFailedDataLength);
 			if (CommandTrace)
-				ZF_LOGI("[ARDOPprotocol.ProcessRcvdFECDataFrame] Pass failed frame ID %s to Host (%d bytes)", Name(intFrameType), bytFailedDataLength);
+				ZF_LOGI("[ARDOPprotocol.ProcessRcvdFECDataFrame] Pass failed frame ID %s to Host (%d bytes)", Name(intLastFailedFrameID), bytFailedDataLength);
 			bytFailedDataLength = 0;
 			intLastFrameIDToHost = intLastFailedFrameID;
-			if (CommandTrace)
-				ZF_LOGI("[ARDOPprotocol.ProcessRcvdFECDataFrame] Pass failed frame ID %s to Host (%d bytes)", Name(intFrameType), bytFailedDataLength);
 		}
 		memcpy(bytFailedData, bytData, frameLen);  // capture the current data and frame type
 		bytFailedDataLength = frameLen;

--- a/src/common/FEC.c
+++ b/src/common/FEC.c
@@ -40,6 +40,11 @@ unsigned int dttLastFECIDSent;
 
 extern int intCalcLeader;  // the computed leader to use based on the reported Leader Length
 
+extern char CarrierOk[8];
+extern int intSumCounts[8];
+extern int intToneMagsAvg[332];
+extern short intCarPhaseAvg[8][652];
+extern short intCarMagAvg[8][652];
 
 // Function to start sending FEC data
 
@@ -355,6 +360,19 @@ void ProcessRcvdFECDataFrame(int intFrameType, UCHAR * bytData, BOOL blnFrameDec
 
 
 		AddTagToDataAndSendToHost(bytData, "FEC", frameLen);
+		// Unlike ProtocolMode ARQ, in FEC mode a data frame of the same type
+		// as the previously recieved data frame might not be a repeat of that
+		// previously recieved data frame.  Resetting CarrierOk ensures that
+		// the next data frame will always be decoded and passed to this
+		// function so that a CRC of its content can be compared to the CRC of
+		// the content of the last data frame recieved to determine whether or
+		// not it is a duplicate.
+		ZF_LOGD("CarrierOk, and data for SavePSKSamples(). reset after FEC frame decoded OK.");
+		memset(CarrierOk, 0, sizeof(CarrierOk));
+		memset(intSumCounts, 0, sizeof(intSumCounts));
+		memset(intToneMagsAvg, 0, sizeof(intToneMagsAvg));
+		memset(intCarPhaseAvg, 0, sizeof(intCarPhaseAvg));
+		memset(intCarMagAvg, 0, sizeof(intCarMagAvg));
 
 		crcLastFECDataPassedToHost = GenCRC16(bytData, frameLen);
 		intLastFrameIDToHost = intFrameType;

--- a/src/common/HostInterface.c
+++ b/src/common/HostInterface.c
@@ -771,7 +771,14 @@ void ProcessCommandFromHost(char * strCMD)
 		{
 			ZF_LOGD("FECRepeats %d", FECRepeats);
 
-			StartFEC(NULL, 0, strFECMode, FECRepeats, FECId);
+			if (!StartFEC(NULL, 0, strFECMode, FECRepeats, FECId)) {
+				// This can occur for several reasons including no data queued
+				// send, an invalid setting for FECREPEATS or FECMODE, MYCALL
+				// not set or invalid.  Previously, no indication was passed
+				// to the host if StartFEC() failed.
+				snprintf(strFault, sizeof(strFault), "StartFEC failed for FECSEND TRUE.");
+				goto cmddone;
+			}
 			SendReplyToHost("FECSEND now TRUE");
 		}
 		else if (strcmp(ptrParams, "FALSE") == 0)

--- a/src/common/SoundInput.c
+++ b/src/common/SoundInput.c
@@ -891,7 +891,7 @@ void ProcessNewSamples(short * Samples, int nSamples)
 			DiscardOldSamples();
 			ClearAllMixedSamples();
 			State = SearchingForLeader;
-			printtick("frame sync timeout");
+//			printtick("frame sync timeout");
 		}
 		intToneMagsIndex = 0;
 	}

--- a/src/common/SoundInput.c
+++ b/src/common/SoundInput.c
@@ -13,8 +13,6 @@
 
 #pragma warning(disable : 4244)  // Code does lots of float to int
 
-#define MEMORYARQ
-
 #undef PLOTWATERFALL
 
 #ifdef PLOTWATERFALL
@@ -131,16 +129,12 @@ short intPhases[8][652] = {0};  // We will decode as soon as we have 4 or 8 depe
 // short intMags[2][195 * 2] = {0};
 short intMags[8][652] = {0};
 
-#ifdef MEMORYARQ
-
-// Enough RAM for memory ARQ so keep all samples for FSK and a copy of tones or phase/amplitude
+// Keep all samples for FSK and a copy of tones or phase/amplitude
 
 int intToneMagsAvg[332];  // ???? FSK Tone averages
 
 short intCarPhaseAvg[8][652];  // array to accumulate phases for averaging (Memory ARQ)
 short intCarMagAvg[8][652];  // array to accumulate mags for averaging (Memory ARQ)
-
-#endif
 
 // If we do Mem ARQ we will need a fair amount of RAM
 
@@ -1084,12 +1078,10 @@ void ProcessNewSamples(short * Samples, int nSamples)
 				// note that although we only do mem arq if enough RAM we
 				// still skip decoding carriers that have been received;
 
-#ifdef MEMORYARQ
 				memset(intSumCounts, 0, sizeof(intSumCounts));
 				memset(intToneMagsAvg, 0, sizeof(intToneMagsAvg));
 				memset(intCarPhaseAvg, 0, sizeof(intCarPhaseAvg));
 				memset(intCarMagAvg, 0, sizeof(intCarMagAvg));
-#endif
 			}
 			else if (ProtocolMode == RXO)
 			{
@@ -4519,8 +4511,6 @@ void DemodPSK()
 
 		}
 
-#ifdef MEMORYARQ
-
 		for (Carrier = 0; Carrier < intNumCar; Carrier++)
 		{
 			if (!CarrierOk[Carrier])
@@ -4556,7 +4546,6 @@ void DemodPSK()
 			if (OKNow && AccumulateStats)
 				intGoodPSKSummationDecodes++;
 		}
-#endif
 
 		// prepare for next
 
@@ -4676,8 +4665,6 @@ VOID InitDemodQAM()
 
 int Demod1CarQAMChar(int Start, int Carrier);
 
-#ifdef MEMORYARQ
-
 // Function to average two angles using magnitude weighting
 
 short WeightedAngleAvg(short intAng1, short intAng2)
@@ -4745,8 +4732,6 @@ void SavePSKSamples(int i)
 	}
 	intSumCounts[i]++;
 }
-
-#endif
 
 BOOL DemodQAM()
 {
@@ -4897,8 +4882,6 @@ BOOL DemodQAM()
 			// Check Data
 
 
-#ifdef MEMORYARQ
-
 			if (!CarrierOk[0] || !CarrierOk[1])
 			{
 				// Decode error - save data for MEM ARQ
@@ -4936,7 +4919,6 @@ BOOL DemodQAM()
 							intGoodQAMSummationDecodes++;
 				}
 			}
-#endif
 			// prepare for next
 
 			DiscardOldSamples();

--- a/src/common/SoundInput.c
+++ b/src/common/SoundInput.c
@@ -1072,6 +1072,10 @@ void ProcessNewSamples(short * Samples, int nSamples)
 
 			if (LastDataFrameType != intFrameType)
 			{
+				// CarrierOk is reset here upon recieving a new frame type.
+				// This is also reset in ProcessRcvFECDataFrame any time an FEC
+				// data frame is correctly decoded since a repeated FEC data
+				// frame type is not always a repetition of the previous frame.
 				ZF_LOGD("New frame type - MEMARQ flags reset");
 				memset(CarrierOk, 0, sizeof(CarrierOk));
 				LastDataFrameType = intFrameType;

--- a/src/common/TCPHostInterface.c
+++ b/src/common/TCPHostInterface.c
@@ -408,13 +408,11 @@ void ProcessReceivedData()
 	// as a command line arguemnt. It is used for all data sent to the TNC, such as
 	// for ARQ or FEC.
 
-	// The command format is expected to be "<LENGTH><MODE><DATA>"
-	// The LENGTH is a two-byte big-endian integer, followed by the text FEC or ARQ, followed by the data.
+	// The command format is expected to be "<LENGTH><DATA>"
+	// The LENGTH is a two-byte big-endian integer, followed by the data.
 	// No carriage return is expected, as the data may contain binary data.
-	// An example valid message is "0008FECHELLO"
-	// This will load FECHELLO into the buffer.
-	// Note that the MODE is included in the length, so the data length is the total length + 3
-	// This behavior is a little strange, to keep the FEC, but right now it is simply what it does.
+	// An example valid message is "0005HELLO"
+	// This will load HELLO into the buffer.
 
 	Len = recv(TCPDataSock, &ARDOPDataBuffer[DataInputLen], 8192 - DataInputLen, 0);
 

--- a/src/common/Webgui.c
+++ b/src/common/Webgui.c
@@ -16,7 +16,7 @@
 
 #define MAX_WG_CLIENTS 4  // maximum number of simultaneous clients
 #define WG_RSIZE 512  // maximum length of messages received from Webgui clients
-#define WG_SSIZE 2048  // maximum length of messages sent to Webgui clients
+#define WG_SSIZE 10000  // maximum length of messages sent to Webgui clients
 #define MAX_AVGLEN 10  // maximum supported length of FFT averaging
 
 extern int wg_port;  // Port number of WebGui.  If 0, no WebGui

--- a/src/linux/ALSASound.c
+++ b/src/linux/ALSASound.c
@@ -2248,7 +2248,9 @@ void DrawRXFrame(int State, const char * Frame)
 	strcpy(&Msg[1], Frame);
 	SendtoGUI('R', Msg, strlen(Frame) + 1);  // RX Frame
 }
-UCHAR Pixels[4096];
+// mySetPixel() uses 3 bytes from Pixels per call.  So it must be 3 times the
+// size of the larger of inPhases[0] or intToneMags/4. (intToneMags/4 is larger)
+UCHAR Pixels[9108];
 UCHAR * pixelPointer = Pixels;
 
 

--- a/src/windows/Waveout.c
+++ b/src/windows/Waveout.c
@@ -1245,8 +1245,9 @@ void CatWrite(char * Buffer, int Len)
 		WriteCOMBlock(hCATDevice, Buffer, Len);
 }
 
-
-UCHAR Pixels[16384];
+// mySetPixel() uses 3 bytes from Pixels per call.  So it must be 3 times the
+// size of the larger of inPhases[0] or intToneMags/4. (intToneMags/4 is larger)
+UCHAR Pixels[9108];
 UCHAR * pixelPointer = Pixels;
 
 

--- a/webgui/webgui.js
+++ b/webgui/webgui.js
@@ -43,7 +43,7 @@ window.addEventListener("load", function(evt) {
 
 	// rsize should match WG_SSIZE in Webgui.c.
 	// This is the maximum length of messages received from ardopcf
-	const rsize = 2048;
+	const rsize = 10000;
 	// ssize should match WG_RSIZE in Webgui.c.
 	// This is the maximum length of messages sent to ardopcf
 	const ssize = 512;


### PR DESCRIPTION
This PR includes several changes that fix bugs and enhance capabilities, mostly relevant to FEC ProtocolMode.  The Memory ARQ improvements should also improve performance in ARQ ProtocolMode when data frames are repeated due to a received DataNAK.

Issue #34 appears to have been caused by a mistaken comment in ProcesReceivedData() in TCPHostInterface.c.  This comment incorrectly described the expected format of data passed to ardop via the TCP data port.  A host program following the information provided in that comment would have produced the problem described in Issued #34.  That comment is corrected. 

Earlier versions of ardopc and ardopcf contained code intended to permit sequential received data frames of the same type to be correctly decoded and their contents passed to a host program when in FEC mode.  However, that functionality was broken.  Code in SoundInput.c related to Memory ARQ was designed for ARQ mode, in which sequential received data frames of the same type can be assumed to be repetitions of the same frame such that they can be discarded if that frame has already been successfully decoded.  This problem was identified in Issue #33.    This PR mostly fixes that issue by evaluating possibly repeated FEC data frames and only discarding them if the contents perfectly match the last data frame received.  This works well when received frames are able to be reliably decoded.  

Unfortunately, when FEC frames, especially multi-carrier frames, cannot be fully decoded the first time they are received, there remains a possibility that different frames will be mistakenly interpreted as copies of the same frame.  This can inhibit decoding and in rare circumstances result in invalid received FEC data containing fragments from two or more data frames being mistakenly interpreted as valid data.  Efforts to mitigate this problem are made, but the limitations of the Ardop protocol do not allow this possibility to be completely eliminated without disabling all Memory ARQ functionality.  Host programs using FEC data should consider implementing higher level message validation protocols to detect and respond to such errors.

It is believed that the problems fixed by this PR could have caused the symptoms described in Issue #35.  That Issue describes repetitions of earlier data being passed to the host in place of newly received data.  This may have been a case of data from two frames being mistakenly combined.  As described above, the likelihood of this occurring has been reduced, but in rare cases it might still occur. 

Earlier versions of ardopc and ardopcf implemented Memory ARQ capabilities.  This is intended to use data collected from repeated transmissions of the same data frame to allow it to be correctly decoded when no single copy could be decoded by itself.  However, this capability was only partially implemented, and there were bugs in some of that implementation which prevented it from working as well as intended.  Those bugs are fixed, and Memory ARQ is now applied to all carriers in all data frame types.  This significantly improves the success rate when receiving repeated copies of the same data frame under poor conditions.  Such repeated frames occur whenever FECREPEATS is set greater than zero in FEC mode and whenever an ARQ data frame is repeated upon receiving a DataNAK.

A minor change was made to the behavior of the host interface in FEC mode.  If "FECSEND TRUE", which is used to initiate transmission of FEC data, fails to send any data, then a FAULT message is passed to the host.  Previously, the host was not notified that a failure had occurred.