### PR TITLE
Handle decoding multiple WAV files specified with --decodewav.

### DIFF
--- a/src/linux/ALSASound.c
+++ b/src/linux/ALSASound.c
@@ -76,7 +76,7 @@ extern BOOL WriteRxWav;
 extern BOOL WriteTxWav;
 extern BOOL TwoToneAndExit;
 extern BOOL FixTiming;
-extern char DecodeWav[256];
+extern char DecodeWav[5][256];
 extern int WavNow;  // Time since start of WAV file being decoded
 
 extern struct sockaddr HamlibAddr;  // Dest for above
@@ -276,7 +276,7 @@ unsigned int getTicks()
 
 	// When decoding a WAV file, return WavNow, a measure of the offset
 	// in ms from the start of the WAV file.
-	if (DecodeWav[0])
+	if (DecodeWav[0][0])
 		return WavNow;
 
 	// Otherwise, return a measure of clock time (also measured in ms).
@@ -415,7 +415,7 @@ int platform_main(int argc, char * argv[])
 	);
 	ZF_LOGD("Command line: %s", cmdstr);
 
-	if (DecodeWav[0])
+	if (DecodeWav[0][0])
 	{
 		decode_wav();
 		return (0);

--- a/src/windows/Waveout.c
+++ b/src/windows/Waveout.c
@@ -132,7 +132,7 @@ extern int useHamLib;
 #define TARGET_RESOLUTION 1  // 1-millisecond target resolution
 
 extern int WavNow;  // Time since start of WAV file being decoded
-extern char DecodeWav[256];
+extern char DecodeWav[5][256];
 extern BOOL WriteTxWav;
 extern BOOL WriteRxWav;
 extern BOOL TwoToneAndExit;
@@ -379,7 +379,7 @@ int platform_main(int argc, char * argv[])
 	);
 	ZF_LOGD("Command line: %s", cmdstr);
 
-	if (DecodeWav[0])
+	if (DecodeWav[0][0])
 	{
 		decode_wav();
 		return (0);
@@ -501,7 +501,7 @@ unsigned int getTicks()
 {
 	// When decoding a WAV file, return WavNow, a measure of the offset
 	// in ms from the start of the WAV file.
-	if (DecodeWav[0])
+	if (DecodeWav[0][0])
 		return WavNow;
 
 	return timeGetTime();


### PR DESCRIPTION
This PR allows up to five WAV recordings to be decoded in sequence by using repeated --decodewav command line arguments.  

Along with the changes made in PR #102 and PR #100, this allows multiple copies of the same WAV recording of a data frame with noise added via the INPUTNOISE host command such that it cannot be decoded by itself, to be to be correctly decoded using Memory ARQ.  This feature was useful in the development and testing of the various enhancements to the Memory ARQ feature. 