### PR TITLE
Implement timer to reset Memory ARQ values.

### DIFF
--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -61,9 +61,7 @@ const char* PlatformSignalAbbreviation(int signal);
 BOOL BusyDetect2(float * dblMag, int intStart, int intStop);
 BOOL IsPingToMe(const StationId* caller, const StationId* target);
 
-void ResetCarrierOk();
-void ResetAvgs();
-extern int LastDataFrameType;
+void ResetMemoryARQ();
 
 void WebguiInit();
 void WebguiPoll();
@@ -638,9 +636,7 @@ void setProtocolMode(char* strMode)
 		return;
 	}
 	// CLear MEM ARQ Stuff
-	ResetCarrierOk();
-	ResetAvgs();
-	LastDataFrameType = -1;
+	ResetMemoryARQ();
 
 	wg_send_protocolmode(0);
 }

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -54,8 +54,7 @@ int bytQDataInProcessLen = 0;  // Length of frame to send/last sent
 
 BOOL blnLastFrameSentData = FALSE;
 
-void ResetCarrierOk();
-void ResetAvgs();
+void ResetMemoryARQ();
 extern int LastDataFrameType;
 extern BOOL blnARQDisconnect;
 extern const short FrameSize[256];
@@ -1229,9 +1228,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 				intLastARQDataFrameToHost = -1;  // precondition to an illegal frame type
 				// CLear MEM ARQ Stuff
-				ResetCarrierOk();
-				ResetAvgs();
-				LastDataFrameType = -1;
+				ResetMemoryARQ();
 
 				// latch the ConReq callsign pair from the decoder
 				memcpy(&ARQStationRemote, &LastDecodedStationCaller, sizeof(ARQStationRemote));
@@ -1309,9 +1306,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 						intLastARQDataFrameToHost = -1;  // precondition to an illegal frame type
 						// CLear MEM ARQ Stuff
-						ResetCarrierOk();
-						ResetAvgs();
-						LastDataFrameType = -1;
+						ResetMemoryARQ();
 
 						intAvgQuality = 0;  // initialize avg quality
 						intReceivedLeaderLen = intLeaderRcvdMs;  // capture the received leader from the remote ISS's ConReq (used for timing optimization)
@@ -1764,9 +1759,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 			intLinkTurnovers += 1;
 			intLastARQDataFrameToHost = -1;  // precondition to an illegal frame type (insures the new IRS does not reject a frame)
 			// CLear MEM ARQ Stuff
-			ResetCarrierOk();
-			ResetAvgs();
-			LastDataFrameType = -1;
+			ResetMemoryARQ();
 			return;
 		}
 		if (intFrameType == DISCFRAME)  // IF DISC received from IRS Handles protocol rule 1.5
@@ -1983,8 +1976,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 					intLinkTurnovers += 1;
 					intLastARQDataFrameToHost = -1;  // precondition to an illegal frame type (insures the new IRS does not reject a frame)
 					// CLear MEM ARQ Stuff
-					ResetCarrierOk();
-					ResetAvgs();
+					ResetMemoryARQ();
 					LastDataFrameType = intFrameType;
 				}
 				else
@@ -2121,8 +2113,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 				intLinkTurnovers += 1;
 				// CLear MEM ARQ Stuff
-				ResetCarrierOk();
-				ResetAvgs();
+				ResetMemoryARQ();
 				LastDataFrameType = intFrameType;
 				intLastARQDataFrameToHost = -1;  // precondition to an illegal frame type (insures the new IRS does not reject a frame)
 				return;


### PR DESCRIPTION
This PR further improves the Memory ARQ feature fixed and extended by PR #101.  In addition to streamlining management of Memory ARQ data, it implements a timer that further reduces the likelihood of data from multiple unrelated data frames incorrectly being combined into what appears to be correctly received data.  This may further help to avoid the problem described in Issue #35. 

FEC data that has not been correctly decoded is passed to the host application tagged with "ERR" to distinguish it from data that is believed to be correct.  The host application can choose whether or not to retain this data and/or display it to the user while appropriately identifying it as containing errors.  In some cases, the data may be mostly correct, such that this imperfect received data is still useful to the user.  The timer implemented by this PR ensures that such data is passed to the host in a timely manner.  Previously, the last frame of such FEC data which could not be correctly decoded may have been passed to the host much later or not at all.