### PR TITLE
Improve handling of station ID transmissions

### DIFF
--- a/src/common/ARDOPC.h
+++ b/src/common/ARDOPC.h
@@ -139,7 +139,7 @@ void StopCodec(char * strFault);
 BOOL SendARQConnectRequest(const StationId* mycall, const StationId* target);
 void AddDataToDataToSend(UCHAR * bytNewData, int Len);
 BOOL StartFEC(UCHAR * bytData, int Len, char * strDataMode, int intRepeats, BOOL blnSendID);
-void SendID(BOOL blnEnableCWID);
+bool SendID(const StationId * id, char * reason);
 // void SetARDOPProtocolState(int value);
 unsigned int GenCRC16(unsigned char * Data, unsigned short length);
 void SendCommandToHost(char * Cmd);
@@ -165,7 +165,7 @@ void SetFilter(void * Filter());
 
 void AddTrailer();
 void CWID(char * strID, short * intSamples, BOOL blnPlay);
-void sendCWID(const StationId* Call, BOOL Play);
+void sendCWID(const StationId * id);
 UCHAR ComputeTypeParity(UCHAR bytFrameType);
 void GenCRC16FrameType(char * Data, int Length, UCHAR bytFrameType);
 BOOL CheckCRC16FrameType(unsigned char * Data, int Length, UCHAR bytFrameType);

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -1513,12 +1513,8 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 				SetARDOPProtocolState(DISC);
 
-				dttLastFECIDSent = Now;
-				if ((EncLen = Encode4FSKIDFrame(&ARQStationLocal, &GridSquare, bytEncodedBytes)) <= 0) {
-					ZF_LOGE("ERROR: In ProcessRcvdARQFrame() for END->IDFrame Invalid EncLen (%d).", EncLen);
-					return;
-				}
-				Mod4FSKDataAndPlay(IDFRAME, &bytEncodedBytes[0], EncLen, 0);  // only returns when all sent
+				// SendID will default to Callsign if ARQStationLocal is not valid.
+				SendID(&ARQStationLocal, "Rcvd END in IRSData or IRSfromISS ARQState");
 
 				InitializeConnection();
 				blnEnbARQRpt = FALSE;
@@ -1797,12 +1793,8 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 			QueueCommandToHost(HostCmd);
 			ClearDataToSend();
 
-			dttLastFECIDSent = Now;
-			if ((EncLen = Encode4FSKIDFrame(&ARQStationLocal, &GridSquare, bytEncodedBytes)) <= 0) {
-				ZF_LOGE("ERROR: In ProcessRcvdARQFrame() for END->IDFrame Invalid EncLen (%d).", EncLen);
-				return;
-			}
-			Mod4FSKDataAndPlay(IDFRAME, &bytEncodedBytes[0], EncLen, 0);  // only returns when all sent
+			// SendID will default to Callsign if ARQStationLocal is not valid.
+			SendID(&ARQStationLocal, "Rcvd END in IDLE ProtocolState");
 
 			SetARDOPProtocolState(DISC);
 			blnEnbARQRpt = FALSE;
@@ -2185,12 +2177,8 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 				ClearDataToSend();
 				blnDISCRepeating = FALSE;
 
-				dttLastFECIDSent = Now;
-				if (EncLen = Encode4FSKIDFrame(&ARQStationLocal, &GridSquare, bytEncodedBytes) <= 0) {
-					ZF_LOGE("ERROR: In ProcessRcvdARQFrame() for END->IDFrame Invalid EncLen (%d).", EncLen);
-					return;
-				}
-				Mod4FSKDataAndPlay(IDFRAME, &bytEncodedBytes[0], EncLen, 0);  // only returns when all sent
+				// SendID will default to Callsign if ARQStationLocal is not valid.
+				SendID(&ARQStationLocal, "Rcvd END in ISSData ARQState");
 
 				SetARDOPProtocolState(DISC);
 				InitializeConnection();
@@ -2411,14 +2399,9 @@ BOOL Send10MinID()
 
 		blnEnbARQRpt = FALSE;
 
-		dttLastFECIDSent = Now;
+		// SendID will default to Callsign if ARQStationLocal is not valid.
+		return SendID(&ARQStationLocal, "10 Minute ID");
 
-		if ((EncLen = Encode4FSKIDFrame(&ARQStationLocal, &GridSquare, bytEncodedBytes)) <= 0) {
-			ZF_LOGE("ERROR: In Send10MinID() Invalid EncLen (%d).", EncLen);
-			return FALSE;
-		}
-		Mod4FSKDataAndPlay(IDFRAME, &bytEncodedBytes[0], EncLen, 0);  // only returns when all sent
-		return TRUE;
 	}
 	return FALSE;
 }

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -1185,6 +1185,13 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, BOOL 
 
 		if (IsCallToMe(&LastDecodedStationCaller, &LastDecodedStationTarget, & bytPendingSessionID))  // (Handles protocol rules 1.2, 1.3)
 		{
+			if (! stationid_ok(&Callsign)) {
+				// ConReq must have matched a value in AuxCalls, but without MYCALL
+				// (Callsign) also set, transmitting is not permitted.
+				ZF_LOGI("[ProcessRcvdARQFrame] ConReq to me decoded, but not responding because MYCALL is not set.");
+				return;
+			}
+
 			BOOL blnLeaderTrippedBusy;
 
 			// This logic works like this:

--- a/src/common/FEC.c
+++ b/src/common/FEC.c
@@ -60,8 +60,6 @@ BOOL StartFEC(UCHAR * bytData, int Len, char * strDataMode, int intRepeats, BOOL
 		ZF_LOGD("[ARDOPprotocol.StartFEC] %d bytes received while in FECSend state...append to data to send.", Len);
 		return TRUE;
 	}
-	else
-		dttLastFECIDSent = Now;
 
 	// Check to see that there is data in the buffer.
 

--- a/src/common/FEC.c
+++ b/src/common/FEC.c
@@ -290,20 +290,8 @@ sendit:
 		txSleep(400);
 
 		if ((Now - dttLastFECIDSent) > 600000)  // 10 Mins
-		{
 			// Send ID every 10 Mins
-
-			unsigned char bytEncodedBytes[16];
-
-			if ((EncLen = Encode4FSKIDFrame(&Callsign, &GridSquare, bytEncodedBytes)) <= 0) {
-				ZF_LOGE("ERROR: In GetNextFECFrame() IDFrame Invalid EncLen (%d).", EncLen);
-				return FALSE;
-			}
-			Mod4FSKDataAndPlay(IDFRAME, &bytEncodedBytes[0], EncLen, 0);  // only returns when all sent
-
-			dttLastFECIDSent = Now;
-			return TRUE;
-		}
+			return SendID(NULL, "FEC 10 minute ID");
 
 		FrameInfo(bytLastFECDataFrameSent, &blnOdd, &intNumCar, strMod, &intBaud, &intDataLen, &intRSLen, &bytMinQualThresh, strType);
 

--- a/src/common/FEC.c
+++ b/src/common/FEC.c
@@ -42,9 +42,13 @@ extern int intCalcLeader;  // the computed leader to use based on the reported L
 void ResetMemoryARQ();
 
 // Function to start sending FEC data
-
 BOOL StartFEC(UCHAR * bytData, int Len, char * strDataMode, int intRepeats, BOOL blnSendID)
 {
+	// Previously this function included a check to ensure that Callsign
+	// was set and valid.  This check is now done in ProcessCommandFromHost().
+	// Moving the check there helps provide a consistent fault message for
+	// any host command that attempts to initiate transmitting without first
+	// setting Callsign.
 	// Return True if OK false if problem
 
 	BOOL blnModeOK = FALSE;
@@ -73,14 +77,6 @@ BOOL StartFEC(UCHAR * bytData, int Len, char * strDataMode, int intRepeats, BOOL
 	if (intRepeats < 0 || intRepeats > 5)
 	{
 		// Logs.Exception("[ARDOPprotocol.StartFEC] Repeats out of range: " & intRepeats.ToString)
-		return FALSE;
-	}
-
-	// check call sign
-
-	if (!stationid_ok(&Callsign))
-	{
-		// Logs.Exception("[ARDOPprotocol.StartFEC] Invalid call sign: " & MCB.Callsign)
 		return FALSE;
 	}
 

--- a/src/common/Modulate.c
+++ b/src/common/Modulate.c
@@ -917,9 +917,8 @@ void Flush()
 
 
 
-// Function to make a CW ID Wave File
-
-void sendCWID(const StationId* station, BOOL blnPlay)
+// Send station id as FSK MORSE
+void sendCWID(const StationId * id)
 {
 	// This generates a phase synchronous FSK MORSE keying of strID
 	// FSK used to maintain VOX on some sound cards
@@ -954,12 +953,12 @@ void sendCWID(const StationId* station, BOOL blnPlay)
 	int idoffset;
 	char gui_frametype[15];
 
-	if (!stationid_ok(station)) {
+	if (!stationid_ok(id)) {
 		ZF_LOGW("Unable to send CWID due to unpopulated station ID");
 		return;
 	}
 
-	snprintf(gui_frametype, sizeof(gui_frametype), "CW.ID.%s", station->call);
+	snprintf(gui_frametype, sizeof(gui_frametype), "CW.ID.%s", id->call);
 	wg_send_txframet(0, gui_frametype);
 
 	// Generate the dot samples (high tone) and space samples (low tone)
@@ -989,9 +988,9 @@ void sendCWID(const StationId* station, BOOL blnPlay)
 		for (i = 0; i < intDotSampCnt; i++)
 			SampleSink(intSpace[i]);
 
-	for (j = 0; j < strnlen(station->call, sizeof(station->call)); j++)
+	for (j = 0; j < strnlen(id->call, sizeof(id->call)); j++)
 	{
-		index = strchr(strAlphabet, station->call[j]);
+		index = strchr(strAlphabet, id->call[j]);
 		if (index)
 			idoffset = index - &strAlphabet[0];
 		else

--- a/src/common/TCPHostInterface.c
+++ b/src/common/TCPHostInterface.c
@@ -845,15 +845,15 @@ Lost:
 			}
 			else if (strcmp(GUIMsg, "SENDID") == 0)
 			{
-				if (ProtocolState == DISC)
+				if (stationid_ok(&Callsign) && ProtocolState == DISC)
 					NeedID = TRUE;  // Send from background
 			}
 			else if (strcmp(GUIMsg, "TWOTONETEST") == 0)
 			{
-				if (ProtocolState == DISC)
+				if (stationid_ok(&Callsign) && ProtocolState == DISC)
 					NeedTwoToneTest = TRUE;  // Send from background
 			}
-			else if (strcmp(GUIMsg, "SENDCWID") == 0)
+			else if (stationid_ok(&Callsign) && strcmp(GUIMsg, "SENDCWID") == 0)
 			{
 				if (ProtocolState == DISC)
 					NeedCWID = TRUE;  // Send from background

--- a/src/common/Webgui.c
+++ b/src/common/Webgui.c
@@ -770,6 +770,8 @@ void WebguiPoll() {
 		case '2':
 			if (ProtocolMode == RXO)
 				wg_send_alert(cnum, "Cannot transmit in RXO ProtocolMode.");
+			else if (! stationid_ok(&Callsign))
+				wg_send_alert(cnum, "Cannot send Two Tone Test.  Callsign not set.");
 			else if (ProtocolState == DISC)
 				NeedTwoToneTest = true;
 			else

--- a/src/common/ardopcommon.h
+++ b/src/common/ardopcommon.h
@@ -129,7 +129,7 @@ void StopCodec(char * strFault);
 BOOL SendARQConnectRequest(const StationId* mycall, const StationId* target);
 void AddDataToDataToSend(UCHAR * bytNewData, int Len);
 BOOL StartFEC(UCHAR * bytData, int Len, char * strDataMode, int intRepeats, BOOL blnSendID);
-void SendID(BOOL blnEnableCWID);
+bool SendID(const StationId * id, char * reason);
 // void SetARDOPProtocolState(int value);
 unsigned int GenCRC16(unsigned char * Data, unsigned short length);
 void SendCommandToHost(char * Cmd);
@@ -154,7 +154,7 @@ void SetFilter(void * Filter());
 
 void AddTrailer();
 void CWID(char * strID, short * intSamples, BOOL blnPlay);
-void sendCWID(const StationId* station, BOOL Play);
+void sendCWID(const StationId * id);
 UCHAR ComputeTypeParity(UCHAR bytFrameType);
 void GenCRC16FrameType(char * Data, int Length, UCHAR bytFrameType);
 BOOL CheckCRC16FrameType(unsigned char * Data, int Length, UCHAR bytFrameType);

--- a/src/common/txframe.c
+++ b/src/common/txframe.c
@@ -242,6 +242,7 @@ int txframe(char * frameParams) {
 		}
 
 		ZF_LOGD("TXFRAME IDFrame %s [%s]", callsign.str, grid.grid);
+		// SendID() always uses global GridSquare, so don't use is here.
 		if ((EncLen = Encode4FSKIDFrame(&callsign, &grid, bytEncodedBytes)) <= 0) {
 			ZF_LOGE("ERROR: In txframe() IDFrame Invalid EncLen (%d).", EncLen);
 			return 1;

--- a/test/python/test_wav_io.py
+++ b/test/python/test_wav_io.py
@@ -49,13 +49,20 @@ def test_contol_wav_io(verbose=1):
                 # CONSOLELOG 2 ensures that the filename of the WAV is
                 # written to stdout so that it can be parsed from
                 # res.stdout.
+                # MYCALL N0CALL sets the station callsign.  Like all
+                # host commands that initiate transmitting, TXFRAME
+                # will respond with a fault message if MYCALL is not
+                # set first.  This is done to ensure that an IDFrame
+                # can be sent when required.  Since the frames generated
+                # by this script will not actaully be transmitted, it
+                # is OK to use a fake callsign.
                 # DRIVELEVEL 30 reduces the volume of the signal in the
                 # WAV file.  This is not expected to impact the ability
                 # of ardopcf to demodulate/decode this WAV file, but it
                 # may be useful if a later stage of this testing uses
                 # noise added to the recording.
                 "--hostcommands",
-                f'CONSOLELOG 2;DRIVELEVEL 30;TXFRAME'
+                f'CONSOLELOG 2;MYCALL N0CALL;DRIVELEVEL 30;TXFRAME'
                 f' {frametype} {paramstr};CLOSE',
             ],
             capture_output=True,
@@ -227,13 +234,20 @@ def test_data_wav_io(verbose=1, sessionid=0xFF):
                         # CONSOLELOG 2 ensures that the filename of the WAV is
                         # written to stdout so that it can be parsed from
                         # res.stdout.
+                        # MYCALL N0CALL sets the station callsign.  Like all
+                        # host commands that initiate transmitting, TXFRAME
+                        # will respond with a fault message if MYCALL is not
+                        # set first.  This is done to ensure that an IDFrame
+                        # can be sent when required.  Since the frames generated
+                        # by this script will not actaully be transmitted, it
+                        # is OK to use a fake callsign.
                         # DRIVELEVEL 30 reduces the volume of the signal in the
                         # WAV file.  This is not expected to impact the ability
                         # of ardopcf to demodulate/decode this WAV file, but it
                         # may be useful if a later stage of this testing uses
                         # noise added to the recording.
                         "--hostcommands",
-                        f'CONSOLELOG 2;DRIVELEVEL 30;TXFRAME'
+                        f'CONSOLELOG 2;MYCALL N0CALL;DRIVELEVEL 30;TXFRAME'
                         f' {frametype[:-1]}{suffix} {rdatahex}'
                         f' 0x{hex(sessionid)[2:]:>02};CLOSE',
                         # Using special audio device name "NOSOUND" tells


### PR DESCRIPTION
Issue #95 pointed out that a station which has automatically sent a PingAck in response to a received Ping (directed to its callsign) is legally required to identify itself, but that this was not occurring.

Further evaluation identified multiple deficiencies in the sending of station ID frames.  These included improper resetting of a timer intended to automatically ID every 10 minutes in both ARQ and FEC mode, and a strong likelihood of transmitting a station ID on top of the other station's CW ID if it sent one at the end of an ARQ session.  Also, the value set by the CWID host command was not always respected when sending an ID.  As a result, if a user/host program intended to have a CW ID transmitted following the 4FSK encoded IDFrame, this didn't always happen.  I interpret FCC rules to not require CW ID, but others may disagree, may want to ID with CW anyways, and/or this feature may be required in other jurisdictions.  So, the CWID host command should be respected.

This PR attempts to ensure that an ID, followed by a CW ID if indicated by the CWID host command, is sent within 10 minutes of any transmission.  In addition to normal ARQ and FEC transmissions, this includes Ping, PingAck, output from the diagnostic TXFRAME command, and even the TwoToneTest signal.  Whenever an ID is sent, including as a part of the ARQ protocol, it respects the CWID preference.  

At the end of an ARQ session, one station sends its ID immediately.  A change made by this PR has the other station wait for the busy detector to indicate that the first station has finished transmitting before sending its own ID.  This ensures if the first station send a CW ID after its 4FSK encoded IDFrame, that the second station's IDFrame will not be sent at the same time.

Because sending of an ID frame is sometimes delayed slightly so as not to disrupt protocol of the ongoing communication, the timer for sending an ID frame is set to 9 minutes rather than 10.  In addition to protocol related delays, detection of other signals by the busy detector can also result in (hopefully minor) delays.  I am aware of one scenario in which sending of an ID frame may be significantly delayed by protocol, such that the 10 minute rule may still be violated.  That can occur during an ARQ session in which one station sends a long sequence of data frames, pausing only for Ack and NAK responses, and perhaps sending its own ID frame.  If this continues for several minutes, the receiving station, which has been transmitting those Ack and NAK responses, and thus is required to ID, may be prevented from doing so in a timely manner.  Currently, it will send a BREAK only when the current sending station runs out of data to send, as indicated by an IDLE frame.  That BREAK will initiate the receiving station becoming the new sending station, at which time it will send and ID frame if its 10 (9) minute timer has elapsed.  Host applications should consider this possibility and thus limit the amount of time used to send any block of data without allowing the other station an opportunity to become the ISS and ID.

While working on this issue, I realized that the implementation of the frame detection/decoding algorithms prevent a station from correctly decoding an IDFrame received while involved in an ARQ session.  Thus, when one station in an ARQ session sends an IDFrame in response to the 10 (9) minute timer, the station that it is communicating with will detect a possible incoming ardop frame, but will experience a failure to decode its frame type.  While I doubt that this was an intentional design choice, it is a logical feature of the mechanism used to ignore any signals that are not a part of the active ARQ session.  Station IDs sent immediately following the end of the ARQ session are correctly decoded.

To ensure that it is possible to send the required ID frames, additional checks are implemented by this PR to prevent transmitting any signal if the users callsign has not been set using the MYCALL host command.  This includes preventing the sending of a TwoToneTest signal.  

Some users may want to use the TwoToneTest signal for antenna tuning and/or checking of audio levels before the host program (which will set MYCALL) is initiated.  Those users may use the --hostcommands "MYCALL XXXX" command line option to automatically set their callsign upon starting ardopcf.

The MYAUX host command allows a station to set additional callsigns.  This allows it to respond to Connect Requests and Pings directed to any of these in addition to the value set by MYCALL.  When a station responds to a Connect Request to a callsign set with MYAUX, that callsign is used for ID purposes for the duration of that ARQ session.  Thus, all values set with MYAUX must be legal callsigns, and not "tactical callsigns" that are insufficient for ID purposes.  Because the Ardop protocol includes the possibility that an ID may be required after the ARQ session was thought to be over, and the value from MYAUX has been forgotten, the new changes require that MYCALL must still be set before a response to a Connect Request or Ping is permitted.  

An ID due to a 10 (9) minute timer started by sending a PingAck will use the value from MYCALL, even if the Ping was to one of the callsigns set with MYAUX.  As indicated in the discussion of Issue #95, development of a better solution to ID when responding to a Ping may still be appropriate.