### PR TITLE
Remove command line options that can be set with --hostcommand

### DIFF
--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -96,6 +96,8 @@ int SpectrumActive = 0;  // Spectrum display off
 StationId ConnectToCall;
 
 int LeaderLength = 240;
+int TrailerLength = 20;
+int extraDelay = 0;  // Used for long delay paths eg Satellite
 unsigned int ARQTimeout = 120;
 int TuningRange = 100;
 int ARQConReqRepeats = 5;
@@ -220,9 +222,6 @@ int closedByPosixSignal = 0;
 BOOL blnCodecStarted = FALSE;
 
 unsigned int dttNextPlay = 0;
-
-extern BOOL InitRXO;
-extern bool DeprecationWarningsIssued;
 
 const UCHAR bytValidFrameTypesALL[] = {
 	DataNAKmin, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
@@ -671,19 +670,10 @@ void ardopmain()
 
 	tmrPollOBQueue = Now + 10000;
 
-	if (InitRXO)
-		setProtocolMode("RXO");
-	else
-		setProtocolMode("ARQ");
+	// Always start in ARQ ProtocolMode.  Use --hostcommands to start in another
+	// ProtocolMode.
+	setProtocolMode("ARQ");
 
-	if (DeprecationWarningsIssued) {
-		ZF_LOGE(
-			"*********************************************************************\n"
-			"* WARNING: DEPRECATED command line parameters used.  Details shown  *\n"
-			"* above.  You may need to scroll up or review the Debug Log file to *\n"
-			"* see those details                                                 *\n"
-			"*********************************************************************\n");
-	}
 	while(!blnClosing)
 	{
 		if (nextHostCommand != NULL) {

--- a/src/common/HostInterface.c
+++ b/src/common/HostInterface.c
@@ -859,7 +859,12 @@ void ProcessCommandFromHost(char * strCMD)
 				LeaderLength = (i + 9) /10;
 				LeaderLength *= 10;  // round to 10 mS
 				// Also set this to intARQDefaultDlyMs to make this equivalent
-				// to the DEPRECATED --leaderlength command line option.
+				// to the obsolete --leaderlength command line option.
+				// TODO:  Need to review use of LeaderLength, intARQDefaultDlyMS,
+				// and intCalcLeader.  It appears that calculation of optimum
+				// leader length (see CalculateOptimumLeader()) is not being done.
+				// It this OK or might implementing (or re-implementing) this
+				// improve reliability under some conditions?
 				intARQDefaultDlyMs = LeaderLength;
 				sprintf(cmdReply, "%s now %d", strCMD, LeaderLength);
 				SendReplyToHost(cmdReply);

--- a/src/linux/ALSASound.c
+++ b/src/linux/ALSASound.c
@@ -46,7 +46,6 @@ int CloseSoundCard();
 int PackSamplesAndSend(short * input, int nSamples);
 BOOL WriteCOMBlock(HANDLE fd, char * Block, int BytesToWrite);
 VOID processargs(int argc, char * argv[]);
-void Send5SecTwoTone();
 int wg_send_currentlevel(int cnum, unsigned char level);
 int wg_send_pttled(int cnum, bool isOn);
 int wg_send_pixels(int cnum, unsigned char *data, size_t datalen);
@@ -71,10 +70,8 @@ BOOL UseRightRX = TRUE;
 BOOL UseLeftTX = TRUE;
 BOOL UseRightTX = TRUE;
 
-extern BOOL InitRXO;
 extern BOOL WriteRxWav;
 extern BOOL WriteTxWav;
-extern BOOL TwoToneAndExit;
 extern BOOL FixTiming;
 extern char DecodeWav[5][256];
 extern int WavNow;  // Time since start of WAV file being decoded
@@ -581,18 +578,6 @@ int platform_main(int argc, char * argv[])
 
 	if (sigaction(SIGPIPE, &act, NULL) < 0)
 		perror ("SIGPIPE");
-
-	if (TwoToneAndExit)
-	{
-		if (!InitSound())
-		{
-			ZF_LOGF("Error in InitSound().  Stopping ardop.");
-			return (0);
-		}
-		ZF_LOGI("Sending a 5 second 2-tone signal. Then exiting ardop.");
-		Send5SecTwoTone();
-		return (0);
-	}
 
 	ardopmain();
 

--- a/src/windows/Waveout.c
+++ b/src/windows/Waveout.c
@@ -121,9 +121,7 @@ LARGE_INTEGER NewTicks;
 
 int LastNow;
 
-extern void Generate50BaudTwoToneLeaderTemplate();
 extern BOOL blnDISCRepeating;
-void Send5SecTwoTone();
 
 extern struct sockaddr HamlibAddr;  // Dest for above
 extern int useHamLib;
@@ -135,7 +133,6 @@ extern int WavNow;  // Time since start of WAV file being decoded
 extern char DecodeWav[5][256];
 extern BOOL WriteTxWav;
 extern BOOL WriteRxWav;
-extern BOOL TwoToneAndExit;
 struct WavFile *rxwf = NULL;
 struct WavFile *txwff = NULL;
 // writing unfiltered tx audio to WAV disabled
@@ -482,17 +479,6 @@ int platform_main(int argc, char * argv[])
 	if(!SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS))
 		printf("Failed to set High Priority (%d)\n"), GetLastError();
 
-	if (TwoToneAndExit)
-	{
-		if (!InitSound(TRUE))
-		{
-			ZF_LOGF("Error in InitSound().  Stopping ardop.");
-			return (0);
-		}
-		ZF_LOGI("Sending a 5 second 2-tone signal. Then exiting ardop.");
-		Send5SecTwoTone();
-		return (0);
-	}
 	ardopmain();
 	return (0);
 }


### PR DESCRIPTION
The last release of ardopcf introduced the --hostcommands command line option, which allows any host command to be executed at startup from the command line.  Several command line options which duplicated functionality that could be achieved with --hostcommands were marked as deprecated.  When those deprecated command line options were used, the user was informed of an equivalent --hostcommands argument and informed that the deprecated option would be removed in a future release of ardopcf.

This PR removes all obsolete command line options that are no longer needed because --hostcommands can achieve the same results.