### PR TITLE
Eliminate use of clock_gettime() in src/common/

### DIFF
--- a/host/python/README.md
+++ b/host/python/README.md
@@ -1,6 +1,6 @@
 ### About `diagnostichost.py`
 
-This directory contains a simple command line python based interactive host program that was created 
+This directory contains a simple command line python based interactive host program that was created
 to facilitate development and debugging work on ardopcf.  **It is not intended for actual communication
 using Ardop.  It is a diagnostic/development tool.** It works on both Linux and Windows, and has
 a very simple text based interface.  It can be used when connected to a headless Linux machine
@@ -33,8 +33,8 @@ module may be run as a script with no installation required. Only modules includ
 standard library are required.
 
 Using the --strings and/or --files option, this can also be used to send commands non-interactively
-to a running Ardop instance from the command line. For non-interactive use, include "::quit" at the
-end of the last string. Without "::quit", --strings and/or --files can be used to configure some
+to a running Ardop instance from the command line. For non-interactive use, include "!!quit" at the
+end of the last string. Without "!!quit", --strings and/or --files can be used to configure some
 settings before beginning interactive use.  See the example_input.txt file for additional details
 and commentary on using --files.
 
@@ -73,18 +73,18 @@ entered as multiple shorter lines.
 Data passed to Ardop is printed as a "DATA >>>>" line. Data from Ardop is printed as
 a "DATA <<" line, which also includes the data type indicator provided by Ardop
 
-A line of input that begins with an colon (:) is passed to the Ardop
+A line of input that begins with an exclamation point (!) is passed to the Ardop
 command socket. Ardop host commands and their parameters are mostly case insensitive.
 Strings passed to the Ardop command port are printed as "CMD  >>>>" lines. Strings
 received from the Ardop command port are printed as "CMD  <<" lines.
 
-Internal commands interpreted by this host program begin with "::". "::quit" exits
-this host program. "::rndXX", "::rndtXX", and "::zerosXX" sends XX random bytes, random
+Internal commands interpreted by this host program begin with "!!". "!!quit" exits
+this host program. "!!rndXX", "!!rndtXX", and "!!zerosXX" sends XX random bytes, random
 printable text bytes, and null bytes respectively to the Ardop data port where XX are
-one or more digits. "::pause" causes a brief delay to let input from Ardop be read and
+one or more digits. "!!pause" causes a brief delay to let input from Ardop be read and
 processed before processing the next line of user input.
 
 #### `example_input.txt`
 
-This file is an example file that can be used as an input script for `diagnostichost.py`.  
+This file is an example file that can be used as an input script for `diagnostichost.py`.
 It contains comments to further explain how such files can be used.

--- a/host/python/diagnostichost.py
+++ b/host/python/diagnostichost.py
@@ -22,8 +22,8 @@ module may be run as a script with no installation required. Only modules includ
 standard library are required.
 
 Using the --strings and/or --files option, this can also be used to send commands non-interactively
-to a running Ardop instance from the command line. For non-interactive use, include "::quit" at the
-end of the last string. Without "::quit", --strings and/or --files can be used to configure some
+to a running Ardop instance from the command line. For non-interactive use, include "!!quit" at the
+end of the last string. Without "!!quit", --strings and/or --files can be used to configure some
 settings before beginning interactive use.  See the example_input.txt file for additional details
 and commentary on using --files.
 """
@@ -208,28 +208,28 @@ class DiagnosticHost():
     def _process_input_line(self, inputline):
         # Process a single line of input from the keyboard (or files or strings)
         data = b''  # no data currently queued to pass to Ardop
-        if inputline.startswith('::'):
+        if inputline.startswith('!!'):
             # A command internal to this host program
-            if inputline.rstrip().lower() == '::quit':
+            if inputline.rstrip().lower() == '!!quit':
                 self._println('(quitting)')
                 time.sleep(0.05)  # Give Ardop time to respond to prior input
                 # This gets responses from Ardop for recent host commands before closing.
                 self._from_ardop()  # Get and process (print) input from Ardop
                 self.close()
                 return False
-            if inputline.rstrip().lower() == '::pause':
+            if inputline.rstrip().lower() == '!!pause':
                 self._println('(pause)')
                 time.sleep(0.05)  # Give Ardop time to respond to prior input
                 self._from_ardop()  # Get and process (print) input from Ardop
-            elif (m := re.fullmatch('::rnd([0-9]+)', inputline.rstrip().lower())) is not None:
+            elif (m := re.fullmatch('!!rnd([0-9]+)', inputline.rstrip().lower())) is not None:
                 data = randbytes(int(m.group(1)))  # random bytes
-            elif (m := re.fullmatch('::rndt([0-9]+)', inputline.rstrip().lower())) is not None:
+            elif (m := re.fullmatch('!!rndt([0-9]+)', inputline.rstrip().lower())) is not None:
                 data = bytes(choices(range(0x20, 0x7E), k=int(m.group(1))))  # printable text
-            elif (m := re.fullmatch('::zeros([0-9]+)', inputline.rstrip().lower())) is not None:
+            elif (m := re.fullmatch('!!zeros([0-9]+)', inputline.rstrip().lower())) is not None:
                 data = b'\x00' * int(m.group(1))  # zero bytes
             else:
                 self._println(f'Ingoring invalid internal command: {inputline}')
-        elif inputline.startswith(':'):
+        elif inputline.startswith('!'):
             # Send to Ardop as a host command
             self._println(f'CMD  >>>> "{inputline[1:]}"')
             try:  # TODO: buffer and select() to send?
@@ -362,14 +362,14 @@ class DiagnosticHost():
         f' entered as multiple shorter lines.\n'
         f'   Data passed to Ardop is printed as a "DATA >>>>" line. Data from Ardop is printed as'
         f' a "DATA <<" line, which also includes the data type indicator provided by Ardop\n'
-        f'   A line of input that begins with an colon (:) is passed to the Ardop'
+        f'   A line of input that begins with an exclamation point (!) is passed to the Ardop'
         f' command socket. Ardop host commands and their parameters are mostly case insensitive.'
         f' Strings passed to the Ardop command port are printed as "CMD  >>>>" lines. Strings'
         f' received from the Ardop command port are printed as "CMD  <<" lines.\n'
-        f'   Internal commands interpreted by this host program begin with "::". "::quit" exits'
-        f' this host program. "::rndXX", "::rndtXX", and "::zerosXX" sends XX random bytes, random'
+        f'   Internal commands interpreted by this host program begin with "!!". "!!quit" exits'
+        f' this host program. "!!rndXX", "!!rndtXX", and "!!zerosXX" sends XX random bytes, random'
         f' printable text bytes, and null bytes respectively to the Ardop data port where XX are'
-        f' one or more digits. "::pause" causes a brief delay to let input from Ardop be read and'
+        f' one or more digits. "!!pause" causes a brief delay to let input from Ardop be read and'
         f' processed before processing the next line of user input.\n')
 
 if __name__ == '__main__':

--- a/host/python/example_input.txt
+++ b/host/python/example_input.txt
@@ -6,30 +6,30 @@
 # Use the -n or --nohelp command line option to not print the interactive usage instructions
 # python diagnostichost.py --nohelp --files example_input.txt
 
-# Lines beginning with a single colon (:) are interpreted as host commands for
-# Ardop.  Lines beginning with two colons (::) are interpreted as internal
-# commands for diagnostichost.py.
+# Lines beginning with a single exclamation point (!) are interpreted as host
+# commands for Ardop.  Lines beginning with two exclamation points (!!) are
+# interpreted as internal commands for diagnostichost.py.
 
 # Commands and Data are sent to Ardop on two different ports.  So, the relative
 # order in which Commands and Data are processed may not be the same as the
 # order in which they are entered.  A "BUFFER" response is returned on the
 # Command port for every block of data submitted to the Data port.  Until that
 # "BUFFER" response is received, the data may or may not have been accepted.
-# ::pause can be used give Ardop time to respond for non-interactive use.
+# !!pause can be used give Ardop time to respond for non-interactive use.
 
 # Most Ardop host commands are case insensitive
 
 # Get the version string for the Ardop implementation that is running.
-:VERSION
+!VERSION
 
 # set the transmit drive level
-:DRIVELEVEL 90
+!DRIVELEVEL 90
 
 # set the level of detail written to the debug log file
-:LOGLEVEL 2
+!LOGLEVEL 2
 
 # set the level of detail written to the conosole
-:CONSOLELOG 3
+!CONSOLELOG 3
 
 # enter some text data
 This is some text data
@@ -37,24 +37,24 @@ This is some text data
 # \xHH can be used to enter text or non-text data
 \x00\x20\xff\x40
 
-# ::rndtXX adds XX random printable text bytes
-::rndt10
+# !!rndtXX adds XX random printable text bytes
+!!rndt10
 
-# ::rndXX adds XX random bytes
-::rnd10
+# !!rndXX adds XX random bytes
+!!rnd10
 
 # Allow some time for Ardop to catch up.  For non-interactive use where
 # sequencing is really important, consider adapting diagnostichost.py to build a
 # tool that watches for and reacts to responses from Ardop.  That would be much
 # more reliable than trying to predict timing.
-::pause
+!!pause
 
 # Clear all data that has been sent to Ardop.  Expect two CMD responses to
-# :PURGEBUFFER.  Expect "BUFFER 0" followed by "PURGEBUFFER"
-:PURGEBUFFER
-::pause
+# !PURGEBUFFER.  Expect "BUFFER 0" followed by "PURGEBUFFER"
+!PURGEBUFFER
+!!pause
 
-# ::zerosXX adds XX null \x00 bytes
-::zeros10
+# !!zerosXX adds XX null \x00 bytes
+!!zeros10
 # If you uncomment the following line, then diagnostichost.py will exit
-#::quit
+#!!quit

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -2615,10 +2615,7 @@ void LogStats()
 	int intTotPSKDecodes = intGoodPSKFrameDataDecodes + intFailedPSKFrameDataDecodes;
 	int i;
 
-	struct timespec tp = { 0, 0 };
-	clock_gettime(CLOCK_REALTIME, &tp);
-
-	ardop_log_session_header(ARQStationRemote.str, &tp, (Now - dttStartSession) / 60000);
+	ardop_log_session_header(ARQStationRemote.str,(Now - dttStartSession) / 60000);
 
 	ardop_log_session_info("     LeaderDetects= %d   AvgLeader S+N:N(3KHz noise BW)= %f dB  LeaderSyncs= %d", intLeaderDetects, dblLeaderSNAvg - 23.8, intLeaderSyncs);
 	ardop_log_session_info("     AvgCorrelationMax:MaxProd= %f over %d  correlations", dblAvgCorMaxToMaxProduct, intEnvelopeCors);

--- a/src/common/log.c
+++ b/src/common/log.c
@@ -1,6 +1,7 @@
 #include "common/log.h"
 
 #include <string.h>
+#include <sys/time.h>
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
@@ -229,7 +230,6 @@ int ardop_log_get_level_file() {
 
 void ardop_log_session_header(
 	const char* remote_callsign,
-	const struct timespec* now,
 	const time_t duration
 )
 {
@@ -238,18 +238,20 @@ void ardop_log_session_header(
 
 	char datefmt[32] = "";
 
-	// convert time_t to calendar time
+	// Get current time and convert to to calendar time
+	struct timeval now;
 	struct tm cal;
-	gmtime_r(&now->tv_sec, &cal);
+	gettimeofday(&now, NULL);
+	gmtime_r((time_t *) &(now.tv_sec), &cal);
 	// 2024-08-10T17:57:36
 	strftime(datefmt, sizeof(datefmt), "%Y-%m-%dT%H:%M:%S", &cal);
 
 	ZF_LOG_WRITE(
 		ZF_LOG_INFO,
 		"A",
-		"%s,%09ld+00:00\n************************* ARQ session stats with %s  %d minutes ****************************\n",
+		"%s,%06ld+00:00\n************************* ARQ session stats with %s  %d minutes ****************************\n",
 		datefmt,
-		now->tv_nsec,
+		now.tv_usec,
 		remote_callsign,
 		(int)duration
 	);

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -237,7 +237,6 @@ int ardop_log_get_level_file();
  * every record.
  *
  * @param[in] remote_callsign  The callsign of the remote station
- * @param[in] now  UNIX time as of session end
  * @param[in] duration  The duration of the session, as a UNIX
  *            time in seconds
  *
@@ -246,7 +245,6 @@ int ardop_log_get_level_file();
  */
 void ardop_log_session_header(
 	const char* remote_callsign,
-	const struct timespec* now,
 	const time_t duration
 );
 

--- a/src/common/log_file.c
+++ b/src/common/log_file.c
@@ -6,6 +6,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/time.h>
 
 #include "common/log.h"
 
@@ -35,10 +36,10 @@ bool ardop_logfile_write(
 	const void* msg,
 	const size_t msglen)
 {
-	struct timespec tp = { 0, 0 };
-	clock_gettime(CLOCK_REALTIME, &tp);
+	struct timeval tv;
+	gettimeofday(&tv, NULL);
 
-	FILE* outfile = ardop_logfile_handle(logfile, tp.tv_sec);
+	FILE* outfile = ardop_logfile_handle(logfile, tv.tv_sec);
 	if (!!outfile) {
 		size_t nwritten = fwrite(msg, msglen, 1, outfile);
 		fflush(outfile);

--- a/src/common/log_file.h
+++ b/src/common/log_file.h
@@ -234,8 +234,8 @@ ARDOP_MUSTUSE bool ardop_logfile_calc_filename(
  * @param[in] current_file_tm  UNIX time at which the current
  *            file was opened.
  *
- * @param[in] now  Current system UNIX time, from clock_gettime()
- *            or similar
+ * @param[in] now  Current system UNIX time (seconds), from
+ *            gettimeofday() or similar
  *
  * @return true if a new log file is needed or false if the
  * current log file is OK.


### PR DESCRIPTION
Use of the clock_getttime() function when compiling for Windows makes the binary dependent on libwinpthread-1.dll which is not available by default on Windows computers.  Thus, such binaries are less portable.  This was not noticed earlier because MinGW provides this dll so that running such binaries works as expected when MinGW is installed to build them.  I've changed my build environment and testing plan so as to notice if similar issues are introduced in the future.

This PR eliminates all use of clock_gettime() in src/common/.  It is still used in src/linux/ files which are not used for Windows builds.

@cbs228, Please be aware of this issue and avoid using clock_gettime() in any future changes you make.

This PR also includes a change in the behavior of the recently introduced diagnostichost.py.  This PR replaces the use of a colon with the use of an exclamation point to distinguish host and internal commands from data.  This makes use of diagnostichost.py more similar to [ARIM](https://www.whitemesa.net/arim/arim.html), an existing tool that provides some similar capabilities.