### PR TITLE
build: statically link all libraries on MinGW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ WIN32 ?= $(filter $(OS),Windows_NT)
 ifneq ($(WIN32),)
 OBJS += $(OBJS_WIN)
 LDLIBS += -lwsock32 -lwinmm -lsetupapi -lws2_32
+LDFLAGS += -static-libgcc -static
 else
 OBJS += $(OBJS_LIN)
 LDLIBS += -lrt -lasound

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -2615,7 +2615,10 @@ void LogStats()
 	int intTotPSKDecodes = intGoodPSKFrameDataDecodes + intFailedPSKFrameDataDecodes;
 	int i;
 
-	ardop_log_session_header(ARQStationRemote.str,(Now - dttStartSession) / 60000);
+	struct timespec tp = { 0, 0 };
+	clock_gettime(CLOCK_REALTIME, &tp);
+
+	ardop_log_session_header(ARQStationRemote.str, &tp, (Now - dttStartSession) / 60000);
 
 	ardop_log_session_info("     LeaderDetects= %d   AvgLeader S+N:N(3KHz noise BW)= %f dB  LeaderSyncs= %d", intLeaderDetects, dblLeaderSNAvg - 23.8, intLeaderSyncs);
 	ardop_log_session_info("     AvgCorrelationMax:MaxProd= %f over %d  correlations", dblAvgCorMaxToMaxProduct, intEnvelopeCors);

--- a/src/common/log.c
+++ b/src/common/log.c
@@ -1,7 +1,6 @@
 #include "common/log.h"
 
 #include <string.h>
-#include <sys/time.h>
 
 #if defined(_WIN32) || defined(_WIN64)
 #include <windows.h>
@@ -230,6 +229,7 @@ int ardop_log_get_level_file() {
 
 void ardop_log_session_header(
 	const char* remote_callsign,
+	const struct timespec* now,
 	const time_t duration
 )
 {
@@ -238,20 +238,18 @@ void ardop_log_session_header(
 
 	char datefmt[32] = "";
 
-	// Get current time and convert to to calendar time
-	struct timeval now;
+	// convert time_t to calendar time
 	struct tm cal;
-	gettimeofday(&now, NULL);
-	gmtime_r((time_t *) &(now.tv_sec), &cal);
+	gmtime_r(&now->tv_sec, &cal);
 	// 2024-08-10T17:57:36
 	strftime(datefmt, sizeof(datefmt), "%Y-%m-%dT%H:%M:%S", &cal);
 
 	ZF_LOG_WRITE(
 		ZF_LOG_INFO,
 		"A",
-		"%s,%06ld+00:00\n************************* ARQ session stats with %s  %d minutes ****************************\n",
+		"%s,%09ld+00:00\n************************* ARQ session stats with %s  %d minutes ****************************\n",
 		datefmt,
-		now.tv_usec,
+		now->tv_nsec,
 		remote_callsign,
 		(int)duration
 	);

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -237,6 +237,7 @@ int ardop_log_get_level_file();
  * every record.
  *
  * @param[in] remote_callsign  The callsign of the remote station
+ * @param[in] now  UNIX time as of session end
  * @param[in] duration  The duration of the session, as a UNIX
  *            time in seconds
  *
@@ -245,6 +246,7 @@ int ardop_log_get_level_file();
  */
 void ardop_log_session_header(
 	const char* remote_callsign,
+	const struct timespec* now,
 	const time_t duration
 );
 

--- a/src/common/log_file.c
+++ b/src/common/log_file.c
@@ -6,7 +6,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/time.h>
 
 #include "common/log.h"
 
@@ -36,10 +35,10 @@ bool ardop_logfile_write(
 	const void* msg,
 	const size_t msglen)
 {
-	struct timeval tv;
-	gettimeofday(&tv, NULL);
+	struct timespec tp = { 0, 0 };
+	clock_gettime(CLOCK_REALTIME, &tp);
 
-	FILE* outfile = ardop_logfile_handle(logfile, tv.tv_sec);
+	FILE* outfile = ardop_logfile_handle(logfile, tp.tv_sec);
 	if (!!outfile) {
 		size_t nwritten = fwrite(msg, msglen, 1, outfile);
 		fflush(outfile);

--- a/src/common/log_file.h
+++ b/src/common/log_file.h
@@ -234,8 +234,8 @@ ARDOP_MUSTUSE bool ardop_logfile_calc_filename(
  * @param[in] current_file_tm  UNIX time at which the current
  *            file was opened.
  *
- * @param[in] now  Current system UNIX time (seconds), from
- *            gettimeofday() or similar
+ * @param[in] now  Current system UNIX time, from clock_gettime()
+ *            or similar
  *
  * @return true if a new log file is needed or false if the
  * current log file is OK.


### PR DESCRIPTION
MinGW includes support libraries like libgcc and libwinpthread. Some toolchains may preferentially link them as DLL dependencies by default. If they are, ardopcf.exe will have runtime dependencies that may be difficult for users to satisfy.

#115 addressed this by removing `clock_gettime()`, which introduced a dependency on `libwinpthread-1.dll`. This problem is likely to recur in the future with other functions. It is difficult to know what they might be in advance. Instead, add additional `LDFLAGS` on Windows to request static linking.

This includes a partial revert of #115 to restore `clock_gettime()`, at least for testing. If that is not ultimately desired, we can still merge this without the reverts.

I have tested this on `i686-w64-mingw32-gcc-posix` from MinGW 13.2 on Linux. I think it works, but it's difficult for me to tell. Static library support may also vary by toolchain. @pflarue, can you test this on Windows with `dumpbin` or equivalent?