### PR TITLE
log,common: add --syslog option on Linux

### DIFF
--- a/docs/Commandline_options.md
+++ b/docs/Commandline_options.md
@@ -74,5 +74,6 @@ All command line options are listed in the following sections. If the option has
 | short option | long option | parameter | description |
 |----|----|----|----|
 | **-m** | **&#8209;&#8209;nologfile** | _none_ | Don't write log files. Use console output only. |
+| **-S** | **&#8209;&#8209;syslog** | _none_ | Send console logs to syslog instead of stderr. Useful mainly for systemd services or daemons. Use the `CONSOLELOG` host command to control the verbosity of syslog messages. Combine with **&#8209;&#8209;nologfile** to use syslog/journald only. (Linux only) |
 | **-l** | **&#8209;&#8209;logdir** | &lt;pathname&gt; | The absolute or relative path where log files and WAV files are written.  Without this option, these files are written to the start directory. |
 | **-G** | **&#8209;&#8209;webgui** | &lt;TCP port&gt; | TCP port to access web GUI. By convention it is number of the host TCP port minus one, so usually 8514.  If a negative TCP port number is given, such as -8514, then the corresponding positive number is used, but the web GUI is opened in developer mode. Developer mode allows arbitrary host commands to be entered from within the web GUI. This is not intended for normal use, but is a useful tool for debugging purposes. |

--- a/src/common/ARDOPCommon.c
+++ b/src/common/ARDOPCommon.c
@@ -21,6 +21,7 @@
 #define SOCKET int
 #define closesocket close
 #define HANDLE int
+#define LOG_OUTPUT_SYSLOG
 #endif
 
 #include <stdbool.h>
@@ -98,6 +99,9 @@ static struct option long_options[] =
 	{"logdir",  required_argument, 0 , 'l'},
 	{"hostcommands",  required_argument, 0 , 'H'},
 	{"nologfile",  no_argument, 0 , 'm'},
+#ifdef LOG_OUTPUT_SYSLOG
+	{"syslog",  no_argument, 0 , 'S'},
+#endif
 	{"ptt",  required_argument, 0 , 'p'},
 	{"cat",  required_argument, 0 , 'c'},
 	{"keystring",  required_argument, 0 , 'k'},
@@ -129,6 +133,9 @@ char HelpScreen[] =
 	"                                       provided by obsolete command line options available\n"
 	"                                       from earlier versions of ardopcf and ardopc.\n"
 	"-m or --nologfile                    Don't write log files. Use console output only.\n"
+#ifdef LOG_OUTPUT_SYSLOG
+	"-S or --syslog                       Send console log to syslog instead.\n"
+#endif
 	"-c device or --cat device            Device to use for CAT Control\n"
 	"-p device or --ptt device            Device to use for PTT control using RTS\n"
 	// RTS:device is also permitted, but is equivalent to just device
@@ -168,6 +175,7 @@ void processargs(int argc, char * argv[])
 	UCHAR * ptr2;
 	int c;
 	bool enable_log_files = true;
+	bool enable_syslog = false;
 	unsigned int WavFileCount = 0;
 
 	while (1)
@@ -213,6 +221,12 @@ void processargs(int argc, char * argv[])
 		case 'm':
 			enable_log_files = false;
 			break;
+
+#ifdef LOG_OUTPUT_SYSLOG
+		case 'S':
+			enable_syslog = true;
+			break;
+#endif
 
 		case 'g':
 			if (optarg)
@@ -421,7 +435,7 @@ void processargs(int argc, char * argv[])
 	ardop_log_set_port(host_port);
 
 	// begin logging
-	ardop_log_start(enable_log_files);
+	ardop_log_start(enable_log_files, enable_syslog);
 }
 
 extern enum _ARDOPState ProtocolState;

--- a/src/common/log.h
+++ b/src/common/log.h
@@ -76,13 +76,15 @@
  *
  * @param[in] enable_files  If true, enable the debug log and
  *            the stats log files.
+ * @param[in] syslog Use syslog instead of the console. Only
+ *            supported on Linux; silently ignored elsewhere.
  *
  * @see ardop_log_set_directory()
  * @see ardop_log_set_port()
  * @see ardop_log_set_level_console()
  * @see ardop_log_set_level_file()
  */
-void ardop_log_start(const bool enable_files);
+void ardop_log_start(const bool enable_files, const bool syslog);
 
 /**
  * @brief Stop logging
@@ -103,11 +105,36 @@ void ardop_log_stop();
  * @see ardop_log_start
  * @see ardop_log_set_level_file
  * @see ardop_log_set_directory
+ * @see ardop_log_enable_files_and_console
  *
  * @note This method has no effect unless logging has been
  * started with \ref ardop_log_start().
  */
 void ardop_log_enable_files(const bool file_output);
+
+/**
+ * @brief Enable or disable logging to files and console
+ *
+ * Closes all log files. If `file_output` is true, file logs
+ * are enabled. Logs will be (re)opened when the next log
+ * message is received. If `syslog` is true, logs are sent
+ * to syslog instead of the console.
+ *
+ * @param[in] file_output   True to enable log files
+ * @param[in] syslog Use syslog instead of the console. Only
+ *            supported on Linux; silently ignored elsewhere.
+ *
+ * @see ardop_log_start
+ * @see ardop_log_set_level_file
+ * @see ardop_log_set_directory
+ *
+ * @note This method has no effect unless logging has been
+ * started with \ref ardop_log_start().
+ */
+void ardop_log_enable_files_and_console(
+	const bool file_output,
+	const bool syslog
+);
 
 /**
  * @brief True if file logging is enabled


### PR DESCRIPTION
Add `--syslog` CLI option to send console logs to syslog(3) instead of stderr. This new behavior is only available and documented on Linux.

The syslog adapter is based on the [example](https://github.com/pflarue/ardop/blob/master/lib/zf_log/examples/custom_output.c) in zf_log. Instead of adding a NUL string terminator, we specify a printf(3)-style *precision*. This keeps the text string compatible with the other output mechanisms, which use that character for newline.

`--syslog` is intended for daemonized unattended use, as one might do with systemd. systemd does not *require* us to use the syslog APIs; it will happily log the process stdout/stderr. Unlike stderr logging, syslog permits us to tag each message with its **priority** level. This means we can search for warnings with:

```bash
journalctl --user -e -p warning
```

An alternative to syslog is to write the priority as a [prefix](https://www.freedesktop.org/software/systemd/man/latest/sd-daemon.html) like

```c
fprintf(stderr, "<4>this is a warning\n");
```

This alternative approach doesn't support non-systemd distros, which are common in the SBC/ARM32 world. It also doesn't support multi-line messages [very easily]. The syslog API is probably the way to go.

This can be tested from the command-line with something like:

```bash
./ardopcf --syslog &
sleep 2
kill %1
journalctl --user -e
```

and noting the presence of `ardopcf` lines. Not all distros provision a `--user` journal. If `journalctl --user -e` is empty or returns an error, that is most likely why. I tested on Ubuntu 24.04.

The CLI argument names and the zf_log→syslog mapping are notional and are good points of discussion.

See discussion in [#122](https://github.com/pflarue/ardop/issues/122#issuecomment-2477898936).