### PR TITLE
Allow user/host controlled writing of WAV files for received audio

### DIFF
--- a/docs/Commandline_options.md
+++ b/docs/Commandline_options.md
@@ -65,7 +65,7 @@ All command line options are listed in the following sections. If the option has
 | **-R** | | _none_ | use only right audio channel for RX. |
 | **-y** |  | _none_ | use only left audio channel for TX. |
 | **-z** | | _none_ | use only left audio channel for TX. |
-| **-w** | **&#8209;&#8209;writewav** |  _none_  | Write WAV files of received audio for debugging. |
+| **-w** | **&#8209;&#8209;writewav** |  _none_  | Write WAV files of received audio for debugging.  (The RECRX host command and a button in the the developer mode version of the WebGui can also be used to start/stop recording of received audio to a WAV file independent this command line option.) |
 | **-T** | **&#8209;&#8209;writetxwav** |  _none_  | Write sent WAV files of received audio for debugging. |
 | **-d** | **&#8209;&#8209;decodewav** |  &lt;pathname&gt;  | Decode the supplied WAV file instead of the input audio.  This option can be repeated up to five times to provide up to five WAV files to be decoded as if they were received in the order provided with a brief period of silence between them. |
 | **-s** | **&#8209;&#8209;sfdt** |  _none_  | Use alternative Sliding DFT based 4FSK decoder. |
@@ -78,4 +78,4 @@ All command line options are listed in the following sections. If the option has
 | **-m** | **&#8209;&#8209;nologfile** | _none_ | Don't write log files. Use console output only. |
 | **-S** | **&#8209;&#8209;syslog** | _none_ | Send console logs to syslog instead of stderr. Useful mainly for systemd services or daemons. Use the `CONSOLELOG` host command to control the verbosity of syslog messages. Combine with **&#8209;&#8209;nologfile** to use syslog/journald only. (Linux only) |
 | **-l** | **&#8209;&#8209;logdir** | &lt;pathname&gt; | The absolute or relative path where log files and WAV files are written.  Without this option, these files are written to the start directory. |
-| **-G** | **&#8209;&#8209;webgui** | &lt;TCP port&gt; | TCP port to access web GUI. By convention it is number of the host TCP port minus one, so usually 8514.  If a negative TCP port number is given, such as -8514, then the corresponding positive number is used, but the web GUI is opened in developer mode. Developer mode allows arbitrary host commands to be entered from within the web GUI. This is not intended for normal use, but is a useful tool for debugging purposes. |
+| **-G** | **&#8209;&#8209;webgui** | &lt;TCP port&gt; | TCP port to access WebGui. By convention it is the number of the host TCP port minus one, so usually 8514.  If a negative TCP port number is given, such as -8514, then the corresponding positive number is used, but the WebGui is opened in developer mode. Developer mode allows arbitrary host commands to be entered from within the WebGui, writes additional details in the WebGui Log display, and provides a button to start/stop recording of RX audio to a WAV file. This is not intended for normal use, but is a useful tool for debugging purposes. |

--- a/docs/Host_Interface_Commands.md
+++ b/docs/Host_Interface_Commands.md
@@ -598,6 +598,35 @@ command, if one was set, remains unchanged.
 string.  As described above, this does not necessarily indicate that Ardop will
 begin using CAT PTT control if it was not already doing so.
 
+#### RECRX
+
+Start (with `RECRX TRUE`) or Stop (with `RECRX FALSE`) recording of received
+audio to a WAV file.  Like those created with the -w or --writewav command line
+options, WAV files are named according to the UTC date and time they are
+started, and are located in the same directory as the debug log file.  The WAV
+files are single channel, 16-bit, 12 kHz sample rate, and thus are suitable to
+be read and decoded by ardopcf with the -d or --decodewav command line option.
+
+`RECRX TRUE` while RECRX is already TRUE or `RECRX FALSE` while RECRX is already
+FALSE is permitted and does nothing.
+
+This command is not intended to be used or useful during normal operation of
+ardopcf.  Rather, it is useful for diagnostic purposes.
+
+- Mode: ANY
+- Arguments: None or `TRUE` or `FALSE`
+- `REXRX` returns `RECRX TRUE` or `RECRX FALSE`
+- `RECRX TRUE` returns `RECRX now TRUE`
+- `RECRX FALSE` returns `RECRX now FALSE`
+- `RECRX Something else` returns `FAULT Syntax Err: RECRX Something else`
+- BUT: If Ardop is currently recording received audio due to the use of the -w
+or --writewav command line options, this command fails and sends
+`FAULT RECRX IGNORED while recording due to -w or --writewav.` to the host.
+Similarly, while RECRX is TRUE, the -w and --writewav command line option is
+temporarily disabled.  Recording due to -w and --writewav may start at the end
+of the next transmission after RECRX is set to FALSE.
+
+
 #### RXLEVEL
 
 Embedded platform control of ADC input volume.

--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -69,6 +69,7 @@ void WebguiPoll();
 int wg_send_fftdata(float *mags, int magsLen);
 int wg_send_busy(int cnum, bool isBusy);
 int wg_send_protocolmode(int cnum);
+int wg_send_wavrx(int cnum, bool isRecording);
 extern int WebGuiNumConnected;
 extern char HostCommands[2048];
 void ProcessCommandFromHost(char * strCMD);
@@ -713,6 +714,7 @@ void ardopmain()
 	if (rxwf != NULL) {
 		CloseWav(rxwf);
 		rxwf = NULL;
+		wg_send_wavrx(0, false);  // update "RECORDING RX" indicator on WebGui
 	}
 	if (txwff != NULL) {
 		CloseWav(txwff);

--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -32,6 +32,7 @@ const char ProductName[] = "ardopcf";
 #include "common/ARDOPC.h"
 #include "common/Locator.h"
 #include "common/StationId.h"
+#include "common/wav.h"
 #include "rockliff/rrs.h"
 
 UCHAR bytDataToSend[DATABUFFERSIZE];
@@ -71,6 +72,11 @@ int wg_send_protocolmode(int cnum);
 extern int WebGuiNumConnected;
 extern char HostCommands[2048];
 void ProcessCommandFromHost(char * strCMD);
+
+extern struct WavFile *rxwf;  // For recording of RX audio
+extern struct WavFile *txwff;  // For recording of filtered TX audio
+// writing unfiltered tx audio to WAV disabled
+// extern struct WavFile *txwfu = NULL;  // For recording of unfiltered TX audio
 
 // Config parameters
 
@@ -702,6 +708,21 @@ void ardopmain()
 			PlatformSignalAbbreviation(closedByPosixSignal)
 		);
 	}
+
+	// If currently recording a WAV file, close it
+	if (rxwf != NULL) {
+		CloseWav(rxwf);
+		rxwf = NULL;
+	}
+	if (txwff != NULL) {
+		CloseWav(txwff);
+		txwff = NULL;
+	}
+	// writing unfiltered tx audio to WAV disabled
+	//if (txwuf != NULL) {
+	//	CloseWav(txwff);
+	//	txwff = NULL;
+	//}
 
 	closesocket(TCPControlSock);
 	closesocket(TCPDataSock);

--- a/src/common/ARDOPCommon.c
+++ b/src/common/ARDOPCommon.c
@@ -61,8 +61,9 @@ int hex2bytes(char *ptr, unsigned int len, unsigned char *output);
 
 int	intARQDefaultDlyMs = 240;
 int wg_port = 0;  // If not changed from 0, do not use WebGui
-BOOL WriteRxWav = FALSE;
-BOOL WriteTxWav = FALSE;
+BOOL HWriteRxWav = FALSE;  // Record RX controlled by host command RECRX
+BOOL WriteRxWav = FALSE;  // Record RX controlled by Command line/TX/Timer
+BOOL WriteTxWav = FALSE;  // Record TX
 BOOL UseSDFT = FALSE;
 BOOL FixTiming = TRUE;
 BOOL WG_DevMode = FALSE;

--- a/src/common/ARDOPCommon.c
+++ b/src/common/ARDOPCommon.c
@@ -450,7 +450,13 @@ void processargs(int argc, char * argv[])
 	}
 
 	if (wg_port < 0) {
-		// This is an "undocumented" feature that may be discontinued in future releases
+		// This enables the WebGui DevMode.  In DevMode, it is possible to send
+		// raw host commands to ardopcf from the WebGui, and additional details
+		// are written to the WebGui Log display.  DevMode also includes a
+		// button to start/stop recording RX audio to a WAV file.  This is
+		// also possible by using the RECRX host command, but the button allows
+		// this to be done more quickly.  The WebGui DevMode is not intended for
+		// normal use, but is a useful tool for debugging purposes.
 		wg_port = -wg_port;
 		WG_DevMode = TRUE;
 	}

--- a/src/common/HostInterface.c
+++ b/src/common/HostInterface.c
@@ -43,6 +43,7 @@ int wg_send_bandwidth(int cnum);
 int wg_send_hostmsg(int cnum, char msgtype, char *strText);
 int wg_send_hostdatab(int cnum, char *prefix, unsigned char *data, int datalen);
 int wg_send_hostdatat(int cnum, char *prefix, unsigned char *data, int datalen);int wg_send_drivelevel(int cnum);
+int wg_send_wavrx(int cnum, bool isRecording);
 
 extern BOOL NeedTwoToneTest;
 extern short InputNoiseStdDev;
@@ -1600,7 +1601,7 @@ void ProcessCommandFromHost(char * strCMD)
 		}
 		DoTrueFalseCmd(strCMD, ptrParams, &HWriteRxWav);  // Also sends reply
 		if (HWriteRxWav && rxwf == NULL) {
-			StartRxWav();
+			StartRxWav();  // This also updates WebGui
 		} else if (rxwf != NULL && !HWriteRxWav) {
 			// This is same condition that was checked before updating
 			// HWriteRxWav.  If true then, it indicated that recording due
@@ -1610,6 +1611,7 @@ void ProcessCommandFromHost(char * strCMD)
 			// So, stop recording.
 			CloseWav(rxwf);
 			rxwf = NULL;
+			wg_send_wavrx(0, false);  // update "RECORDING RX" indicator on WebGui
 		}
 		goto cmddone;
 	}

--- a/src/common/Webgui.c
+++ b/src/common/Webgui.c
@@ -247,6 +247,8 @@ int decodeUvint(struct wg_receive_data *rdata) {
 // "S|" no additional data: ISS true
 // "s|" no additional data: ISS false
 // "t|" followed by a string: Protocol State
+// "W|" no additional data: Recording RX true
+// "w|" no additional data: Recording RX false
 // 0x817C followed by one additional byte interpreted as an unsigned
 //   char in the range of 0 to 150: Set CurrentLevel
 // 0x8A7C
@@ -514,6 +516,13 @@ int wg_send_busy(int cnum, bool isBusy) {
 		return wg_send_msg(cnum, "B|", 2);
 	else
 		return wg_send_msg(cnum, "b|", 2);
+}
+
+int wg_send_wavrx(int cnum, bool isRecording) {
+	if (isRecording)
+		return wg_send_msg(cnum, "W|", 2);
+	else
+		return wg_send_msg(cnum, "w|", 2);
 }
 
 int wg_send_pixels(int cnum, unsigned char *data, size_t datalen) {

--- a/src/linux/ALSASound.c
+++ b/src/linux/ALSASound.c
@@ -49,6 +49,7 @@ VOID processargs(int argc, char * argv[]);
 int wg_send_currentlevel(int cnum, unsigned char level);
 int wg_send_pttled(int cnum, bool isOn);
 int wg_send_pixels(int cnum, unsigned char *data, size_t datalen);
+int wg_send_wavrx(int cnum, bool isRecording);
 void WebguiPoll();
 
 int add_noise(short *samples, unsigned int nSamples, short stddev);
@@ -189,6 +190,7 @@ void StartRxWav()
 		return;
 	}
 	rxwf = OpenWavW(rxwf_pathname);
+	wg_send_wavrx(0, true);  // update "RECORDING RX" indicator on WebGui
 	if (!HWriteRxWav) {
 		// A timer is not used with HWriteRxWav, so no need to extend.
 		extendRxwf();
@@ -1752,6 +1754,7 @@ void PollReceivedSamples()
 				// timer to close WAV file has expired (not used with HWriteRxWav)
 				CloseWav(rxwf);
 				rxwf = NULL;
+				wg_send_wavrx(0, false);  // update "RECORDING RX" indicator on WebGui
 			}
 			else
 				WriteWav(&inbuffer[0][0], ReceiveSize, rxwf);

--- a/src/windows/Waveout.c
+++ b/src/windows/Waveout.c
@@ -120,6 +120,7 @@ void WebguiPoll();
 int wg_send_currentlevel(int cnum, unsigned char level);
 int wg_send_pttled(int cnum, bool isOn);
 int wg_send_pixels(int cnum, unsigned char *data, size_t datalen);
+int wg_send_wavrx(int cnum, bool isRecording);
 
 int Ticks;
 
@@ -215,6 +216,7 @@ void StartRxWav()
 	}
 
 	rxwf = OpenWavW(rxwf_pathname);
+	wg_send_wavrx(0, true);  // update "RECORDING RX" indicator on WebGui
 	if (!HWriteRxWav) {
 		// A timer is not used with HWriteRxWav, so no need to extend.
 		extendRxwf();
@@ -816,6 +818,7 @@ void PollReceivedSamples()
 				// timer to close WAV file has expired (not used with HWriteRxWav)
 				CloseWav(rxwf);
 				rxwf = NULL;
+				wg_send_wavrx(0, false);  // update "RECORDING RX" indicator on WebGui
 			}
 			else
 				WriteWav(&inbuffer[inIndex][0], inheader[inIndex].dwBytesRecorded/2, rxwf);

--- a/webgui/webgui.html
+++ b/webgui/webgui.html
@@ -7,7 +7,7 @@
 		<style type="text/css">
 			#spectrum {vertical-align: bottom;}
 			#busy {background-color: gold;}
-			#ptt {background-color: red;}
+			#ptt, #recordingrx {background-color: red;}
 			#iss, #irs {background-color: lime;}
 			#lostcon {background-color: hotpink;}
 			#rcvoverflow {background-color: hotpink;}
@@ -44,6 +44,7 @@
 		<div>
 			<span id="ptt" class="hidden">&nbsp;PTT&nbsp;</span>
 			<span id="busy" class="hidden">Channel Busy</span>
+			<span id="recordingrx" class="hidden">RECORDING RX</span>
 		</div>
 		<div>
 			<span id="mycall">(MYCALL NOT SET)</span>
@@ -134,8 +135,14 @@
 				<dt>'IDLE'</dt><dd>idle</dd>
 			</dl>
 			</p><p>
-			The next blank line will show <b>'PTT'</b> when transmitting and <b>'Channel Busy'</b> when
-			the busy detector detects a signal within Ardop's current bandwidth settings.
+			The next blank line will show <b>'PTT'</b> when transmitting, <b>'Channel Busy'</b>
+			when the busy detector detects a signal within Ardop's current bandwidth settings,
+			and <b>RECORDING RX</b> when ardopcf is writing a WAV file containing the received
+			audio.  Such recording happens after transmitting when the -w or --writewav command
+			line option is used, as well as in response to the RECRX host command.  No data is
+			written to this WAV file while transmitting, but this indicator remains on while
+			transmitting since writing of data automatically resumes at the end of the
+			transmission.
 			</p><p>
 			The next line shows the value of <b>MYCALL</b> and the callsign of the station you
 			are connected to or sending Connection Requests (ConReq) to.  MYCALL is
@@ -336,6 +343,7 @@
 			</p>
 		</div>
 		<div id="devmode" class="dnone">
+			<button id="recrx">Start RX Recording</button><br />
 			Host Command: <input type="text"  id="hostcommand"></input>
 		</div>
 	</body>

--- a/webgui/webgui.js
+++ b/webgui/webgui.js
@@ -414,6 +414,8 @@ window.addEventListener("load", function(evt) {
 		// "S|" no additional data: ISS true
 		// "s|" no additional data: ISS false
 		// "t|" followed by a string: Protocol State
+		// "W|" no additional data: Recording RX true
+		// "w|" no additional data: Recording RX false
 		// 0x817C followed by one additional byte interpreted as an unsigned
 		//   char in the range of 0 to 150: Set CurrentLevel
 		// 0x8A7C
@@ -737,6 +739,20 @@ window.addEventListener("load", function(evt) {
 					document.getElementById("state").innerHTML = state;
 					break;
 				}
+				case "W":
+					// Recording RX WAV true
+					// This may be due to RECRX host command or from use of
+					// -w or --writewav command line option (triggered after TX)
+					document.getElementById("recordingrx").classList.remove("hidden");
+					break;
+				case "w": {
+					// Recording RX WAV false
+					// This may be due to RECRX host command or end of timer
+					// for recording started due to -w or --writewav command
+					// line option.
+					document.getElementById("recordingrx").classList.add("hidden");
+					break;
+				}
 				case "\x81": {
 					// CurrentLevel update
 					// linear fraction of recieved fullscale audio scale
@@ -909,6 +925,16 @@ window.addEventListener("load", function(evt) {
 		// cursor movement keys (to allow keyboard scrolling).
 		if (evt.keyCode < 33 || evt.keyCode > 40)
 			evt.preventDefault();
+	};
+
+	document.getElementById("recrx").onclick = function() {
+		if (document.getElementById("recrx").innerHTML == "Start RX Recording") {
+			send_msg(encoder.encode("H~RECRX TRUE"), 12);
+			document.getElementById("recrx").innerHTML = "Stop RX Recording";
+		} else {
+			send_msg(encoder.encode("H~RECRX FALSE"), 13);
+			document.getElementById("recrx").innerHTML = "Start RX Recording";
+		}
 	};
 
 	document.getElementById("hostcommand").onkeydown = function(evt) {


### PR DESCRIPTION
The existing `--writewav` or `-w` command line option allows recording of the audio received during a ARQ session.  When that option is used, recording is automatically started after TX, and should continue until the end of the ARQ session.  However, there was no way to record received audio when in RXO mode or when receiving an extended FEC transmission.

The new RECRX host command allows recording of RX audio to be directly controlled by the user/host.  This has proven very useful for development/debugging purposes.  To allow convenient use of this capability, a button is added to the WebGui when it is in Developer Mode as initiated by providing a negative port number as the argument to the `--webgui` or `-G` option. This button starts/stops recording of RX audio.  An indicator is also added to the Webgui to indicate whenever RX audio is being recorded. 