### PR TITLE
Expand lists of data frame types used when FSKONLY TRUE

### DIFF
--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -570,21 +570,21 @@ bool IsPingToMe(const StationId* caller, const StationId* target)
 // 4FSK.200.50S, 4PSK.200.100S, 4PSK.200.100, 8PSK.200.100, 16QAM.200.100
 
 static UCHAR DataModes200[] = {0x48, 0x42, 0x40, 0x44, 0x46};
-static UCHAR DataModes200FSK[] = {0x48};
+static UCHAR DataModes200FSK[] = {0x48};  // 4FSK.200.50S
 
 // 4FSK.200.50S, 4PSK.200.100S, 4PSK.200.100, 4PSK.500.100, 8PSK.500.100, 16QAM.500.100)
 // (310, 436, 756, 1509, 2566, 3024 bytes/min)
 // Dim byt500 As Byte() = {&H48, &H42, &H40, &H50, &H52, &H54}
 
 static UCHAR DataModes500[] = {0x48, 0x42, 0x40, 0x50, 0x52, 0x54};
-static UCHAR DataModes500FSK[] = {0x48};
+static UCHAR DataModes500FSK[] = {0x48, 0x4C, 0x4A};  // 4FSK.200.50S, 4FSK.500.100S, 4FSK.500.100
 
 
 // 4FSK500.100S, 4FSK500.100, 4PSK500.100, 4PSK1000.100, 8PSK.1000.100
 // (701, 865, 1509, 3018, 5133 bytes/min)
 
 static UCHAR DataModes1000[] = {0x4C, 0x4A, 0x50, 0x60, 0x62, 0x64};
-static UCHAR DataModes1000FSK[] = {0x4C, 0x4A};
+static UCHAR DataModes1000FSK[] = {0x48, 0x4C, 0x4A};  // 4FSK.200.50S, 4FSK.500.100S, 4FSK.500.100
 
 // 2000 Non-FM
 
@@ -593,7 +593,7 @@ static UCHAR DataModes1000FSK[] = {0x4C, 0x4A};
 // Dim byt2000 As Byte() = {&H4C, &H4A, &H50, &H60, &H70, &H72, &H74}. Note addtion of 16QAM 8 carrier mode 16QAM2000.100.E/O
 
 static UCHAR DataModes2000[] = {0x4C, 0x4A, 0x50, 0x60, 0x70, 0x72, 0x74};
-static UCHAR DataModes2000FSK[] = {0x4C, 0x4A};
+static UCHAR DataModes2000FSK[] = {0x48, 0x4C, 0x4A};  // 4FSK.200.50S, 4FSK.500.100S, 4FSK.500.100
 
 // 2000 FM
 // These include the 600 baud modes for FM only.
@@ -604,7 +604,8 @@ static UCHAR DataModes2000FSK[] = {0x4C, 0x4A};
 // Dim byt2000 As Byte() = {&H4C, &H4A, &H7C, &H7A}
 
 static UCHAR DataModes2000FM[] = {0x4C, 0x4A, 0x7C, 0x7A};
-static UCHAR DataModes2000FMFSK[] = {0x4C, 0x4A, 0x7C, 0x7A};
+// 4FSK.200.50S, 4FSK.500.100S, 4FSK.500.100, 4FSK.2000.600S, 4FSK.2000.600
+static UCHAR DataModes2000FMFSK[] = {0x48, 0x4C, 0x4A, 0x7C, 0x7A};
 
 static UCHAR NoDataModes[1] = {0};
 


### PR DESCRIPTION
Minor adjustment to expand the lists of frame types that can be used for each bandwidth value when FSKONLY TRUE is used.