### PR TITLE
Refactor alsa audio

### DIFF
--- a/docs/Commandline_options.md
+++ b/docs/Commandline_options.md
@@ -21,7 +21,7 @@ _ardopcf_ will list all available capture and playback devices when started. Eac
 Example: startup shows the following list
 ```
 ardopcf Version 1.0.4.1.3 (https://www.github.com/pflarue/ardop)
-Copyright (c) 2014-2024 Rick Muething, John Wiseman, Peter LaRue
+Copyright (c) 2014-2025 Rick Muething, John Wiseman, Peter LaRue
 See https://github.com/pflarue/ardop/blob/master/LICENSE for licence details including
 information about authors of external libraries used and their licenses.
 Capture Devices
@@ -48,7 +48,7 @@ _(In this example we omitted CAT/PTT options, see below in section 3)_
 
 ### Audio device selection in Linux
 
-_ardopcf_ will list all available ALSA capture and playback devices when started.  If your Linux computer is running PulseAudio, it may also work to specify `pulse` as an audio device.  `pulse` will never be listed as an available audio device by ardopcf.
+_ardopcf_ will list all available (hardware) ALSA capture and playback devices when started.  If your Linux computer is running PulseAudio, it may also work to specify `pulse` as an audio device.  `pulse` will never be listed as an available audio device by ardopcf.
 
 Example: startup shows the following list
 ```
@@ -95,6 +95,8 @@ or
 ardopcf -i 1 -o 1
 ```
 
+While these ALSA audio devices should work on all Linux computers, the use of `pulse` audio devices are also available on many systems.  See [USAGE_linux.md](USAGE_linux.md) for details of how to use `pulse` devices, as well as how to configure ardopcf so that it can share audio devices with other programs.
+
 _(In this example we omitted CAT/PTT options, see below in section 3)_
 
 All command line options are listed in the following sections. If the option has an argument, it follows the option after a space.
@@ -132,7 +134,6 @@ All command line options are listed in the following sections. If the option has
 | **-T** | **&#8209;&#8209;writetxwav** |  _none_  | Write WAV files of transmitted audio for debugging. |
 | **-d** | **&#8209;&#8209;decodewav** |  &lt;pathname&gt;  | Decode the supplied WAV file instead of the input audio.  This option can be repeated up to five times to provide up to five WAV files to be decoded as if they were received in the order provided, with a brief period of silence between them.  Unlike handling of most other command line arguments, the --hostcommands (or -H) option is processed before the WAV files are processed.  After these WAV files have been processed, ardopcf will exit. |
 | **-s** | **&#8209;&#8209;sfdt** |  _none_  | Use alternative Sliding DFT based 4FSK decoder. |
-| **-A** | **&#8209;&#8209;ignorealsaerror** |  _none_ | Ignore ALSA config error that causes timing error. <br> **DO NOT** use -A option except for testing/debugging, or if ardopcf fails to run and suggests trying this. |
 
 ## 5. Other options
 

--- a/docs/example.asoundrc
+++ b/docs/example.asoundrc
@@ -1,0 +1,41 @@
+# Copy this file to ~/.asoundrc
+#
+# To share audio devices between multiple programs, use mixN for playback
+# and snoopN for capture, where N is the corresponding card number of the
+# device to be shared, as listed with the -l option of aplay and arecord.
+#
+# This file, which is available at
+# https://github.com/pflarue/ardop/blob/master/docs/example.asoundrc
+# provides mixed/snooped versions for cards 0 and 1.  These can be copied and
+# edited for additional card numbers as required.
+#
+# This file is generally only required on Linux systems that have only the
+# default ALSA sound system installed.  If you are using a Linux system running
+# PulseAudio or another audio server system that provides a "pulse" PCM as
+# listed with the -L option of aplay and arecord, then that pulse device should
+# generally be used when an audio device is to be shared between multiplt
+# programs.  When pulse is used, this file is not required.
+
+pcm.mix0 {
+	type plug
+	slave.pcm "dmix:0,0"
+	hint.description "Resample and mix (play) hw:0,0"
+}
+
+pcm.mix1 {
+	type plug
+	slave.pcm "dmix:1,0"
+	hint.description "Resample and mix (play) hw:1,0"
+}
+
+pcm.snoop0 {
+	type plug
+	slave.pcm "dsnoop:0,0"
+	hint.description "Resample and snoop (capture) hw:0,0"
+}
+
+pcm.snoop1 {
+	type plug
+	slave.pcm "dsnoop:1,0"
+	hint.description "Resample and snoop (capture) hw:1,0"
+}

--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -173,7 +173,16 @@ struct SEM Semaphore = {0, 0, 0, 0};
 bool SoundIsPlaying = false;
 bool Capturing = true;
 
-int DecodeCompleteTime;
+// DecodeCompleteTime is the value of Now when the most recent received frame
+// was decoded.  Initializing it to 0 should normally ensure that
+// DecodeCompleteTime is less than future values of Now, avoiding an unexpected
+// and excessive delay if attempting to transmit before ever decoding any
+// recevied frames.
+// TODO: Now, as defined in windows/os_util.c (for windows) is the time since
+// windows was started, which resets every 2^32 ms, which is about 50 days.
+// While this is unlikely to occur, something should be implemented to keep
+// this from causing a problem.
+int DecodeCompleteTime = 0;
 
 bool blnAbort = false;
 int intRepeatCount;

--- a/src/common/ARDOPC.h
+++ b/src/common/ARDOPC.h
@@ -176,6 +176,7 @@ VOID ClearBusy();
 VOID CloseCOMPort(HANDLE fd);
 
 // #ifdef WIN32
+bool PreprocessNewSamples(short * Samples, int nSamples);
 void ProcessNewSamples(short * Samples, int nSamples);
 void ardopmain();
 bool GetNextFECFrame();

--- a/src/common/ARDOPCommon.c
+++ b/src/common/ARDOPCommon.c
@@ -122,15 +122,19 @@ void StartRxWav() {
 	// written to the Log directory if defined, else to the current
 	// directory
 	//
-	// As currently implemented, the wav file written contains only
-	// received audio.  Since nothing is written for the time while
-	// transmitting, and thus not receiving, this recording is not
-	// time continuous.  Thus, the filename indicates the time that
-	// the recording was started, but the times of the received
-	// transmissions, other than the first one, are not indicated.
-	// The size should be 100 larger than the size of ArdopLogDir in log.c so
-	// that a WAV pathname in the directory from ardop_log_get_directory()
-	// will always fit.
+	// The wav file written contains only received audio, but continues to
+	// record while transmitting.  While transmitting, the recorded audio is
+	// usually near silence, but not always.  Depending on the hardware in use,
+	// artifacts of PTT on/off may be discernable, as well as the changes in
+	// noise level following PTT action.  Because recording is not interrupted
+	// while transmitting, the timing between various received audio features
+	// should be accurate, and the absolute time at which any audio was received
+	// can be approximately calculated based on the offset within the recording
+	// added to the time indicated by the filename.
+	//
+	// The size of rxwf_pathname should be 100 larger than the size of
+	// ArdopLogDir in log.c so that a WAV pathname in the directory from
+	// ardop_log_get_directory() will always fit.
 	char rxwf_pathname[612];
 	int pnlen;
 	char timestr[16];  // 15 char time string plus terminating NULL
@@ -849,14 +853,14 @@ void displayCall(int dirn, const char * Call)
 
 // When decoding WAV files, WavNow will be set to the offset from the
 // start of that file to the end of the data about to be passed to
-// ProcessNewSamples() in ms.  Thus, it serves as a proxy for Now
-// which is otherwise based on clock time.  This substitution occurs
-// in getNow() in os_util.c.  It is also used to indicate time offsets
-// in the log file.
+// ProcessNewSamples() in ms.  This is returned by Now rather than the
+// value typically provided based on clock time.  This substitution occurs
+// in getNow() in os_util.c.  While the timestamps in the log file are always
+// based on clock time, values of WavNow are also logged (with level VERBOSE)
+// at 100 ms intervals.
 int WavNow = 0;
 
-int decode_wav()
-{
+int decode_wav() {
 	FILE *wavf;
 	unsigned char wavHead[44];
 	size_t readCount;
@@ -864,10 +868,11 @@ int decode_wav()
 	unsigned int nSamples;
 	int sampleRate;
 	short samples[1024];
+	// For logging of WavNow, 100 ms must be a multiple of the duration
+	// corresponding to blocksize.
 	const unsigned int blocksize = 240;  // Number of 16-bit samples to read at a time
 	int WavFileCount = 0;
 	char *nextHostCommand = HostCommands;
-	bool warnedClipping = false;  // Use this to only log warning about clipping once.
 
 	// Seed the random number generator.  This is useful if INPUTNOISE is being
 	// used.  Seeding is normally done in ardopmain(), which is bypassed when
@@ -893,7 +898,6 @@ int decode_wav()
 
 	// Send blocksize silent/noise samples to ProcessNewSamples() before start of WAV file data.
 	memset(samples, 0, sizeof(samples));
-	add_noise(samples, blocksize, InputNoiseStdDev);
 	ProcessNewSamples(samples, blocksize);
 
 	WavNow = 0;
@@ -903,63 +907,48 @@ int decode_wav()
 		NowOffset = Now;
 		ZF_LOGI("Decoding WAV file %s.", DecodeWav[WavFileCount]);
 		wavf = fopen(DecodeWav[WavFileCount], "rb");
-		if (wavf == NULL)
-		{
+		if (wavf == NULL) {
 			ZF_LOGE("Unable to open WAV file %s.", DecodeWav[WavFileCount]);
 			return 1;
 		}
 		if ((Now - NowOffset) % 100 == 0)  // time stamp at 100 ms intervals
 			ZF_LOGV("%s: %.3f sec (%.3f)", DecodeWav[WavFileCount], (Now - NowOffset)/1000.0, Now/1000.0);
 		readCount = fread(wavHead, 1, 44, wavf);
-		if (readCount != 44)
-		{
+		if (readCount != 44) {
 			ZF_LOGE("Error reading WAV file header.");
 			return 2;
 		}
-		if (memcmp(wavHead, headStr, 4) != 0)
-		{
+		if (memcmp(wavHead, headStr, 4) != 0) {
 			ZF_LOGE("%s is not a valid WAV file. 0x%x %x %x %x != 0x%x %x %x %x",
 						DecodeWav[WavFileCount], wavHead[0], wavHead[1], wavHead[2],
 						wavHead[3], headStr[0], headStr[1], headStr[2], headStr[3]);
 			return 3;
 		}
-		if (wavHead[20] != 0x01)
-		{
+		if (wavHead[20] != 0x01) {
 			ZF_LOGE("Unexpected WAVE type.");
 			return 4;
 		}
-		if (wavHead[22] != 0x01)
-		{
+		if (wavHead[22] != 0x01) {
 			ZF_LOGE("Expected single channel WAV.  Consider converting it with SoX.");
 			return 7;
 		}
 		sampleRate = wavHead[24] + (wavHead[25] << 8) + (wavHead[26] << 16) + (wavHead[27] << 24);
-		if (sampleRate != 12000)
-		{
+		if (sampleRate != 12000) {
 			ZF_LOGE("Expected 12kHz sample rate but found %d Hz.  Consider converting it with SoX.", sampleRate);
 			return 8;
 		}
 
 		nSamples = (wavHead[40] + (wavHead[41] << 8) + (wavHead[42] << 16) + (wavHead[43] << 24)) / 2;
 		ZF_LOGD("Reading %d 16-bit samples.", nSamples);
-		while (nSamples >= blocksize)
-		{
+		while (nSamples >= blocksize) {
 			readCount = fread(samples, 2, blocksize, wavf);
-			if (readCount != blocksize)
-			{
+			if (readCount != blocksize) {
 				ZF_LOGE("Premature end of data while reading WAV file.");
 				return 5;
 			}
 			WavNow += blocksize * 1000 / 12000;
 			if ((Now - NowOffset) % 100 == 0)  // time stamp at 100 ms intervals
 				ZF_LOGV("%s: %.3f sec (%.3f)", DecodeWav[WavFileCount], (Now - NowOffset)/1000.0, Now/1000.0);
-			if (add_noise(samples, blocksize, InputNoiseStdDev) > 0 && !warnedClipping) {
-				// The warning normally logged when audio is too loud does not
-				// appear when using decode_wav().  So, add it here.
-				ZF_LOGI("WARNING: In decode_wav(), samples are clipped after adding"
-					" noise because they exceeded the range of a 16-bit integer.");
-				warnedClipping = true;
-			}
 			ProcessNewSamples(samples, blocksize);
 			nSamples -= blocksize;
 		}
@@ -970,21 +959,13 @@ int decode_wav()
 		// convenient for logging).
 		memset(samples, 0, sizeof(samples));
 		readCount = fread(samples, 2, nSamples, wavf);
-		if (readCount != nSamples)
-		{
+		if (readCount != nSamples) {
 			ZF_LOGE("Premature end of data while reading WAV file.");
 			return 6;
 		}
 		WavNow += blocksize * 1000 / 12000;
 		if ((Now - NowOffset) % 100 == 0)  // time stamp at 100 ms intervals
 			ZF_LOGV("%s: %.3f sec (%.3f)", DecodeWav[WavFileCount], (Now - NowOffset)/1000.0, Now/1000.0);
-		if (add_noise(samples, blocksize, InputNoiseStdDev) > 0 && !warnedClipping) {
-			// The warning normally logged when audio is too loud does not
-			// appear when using decode_wav().  So, add it here.
-			ZF_LOGI("WARNING: In decode_wav(), samples are clipped after adding"
-				" noise because they exceeded the range of a 16-bit integer.");
-			warnedClipping = true;
-		}
 		ProcessNewSamples(samples, blocksize);
 		nSamples = 0;
 		fclose(wavf);
@@ -1008,7 +989,6 @@ int decode_wav()
 			WavNow += blocksize * 1000 / 12000;
 			if ((Now - NowOffset) % 100 == 0)  // time stamp at 100 ms intervals
 				ZF_LOGV("Added silence/noise: %.3f sec (%.3f)", (Now - NowOffset)/1000.0, Now/1000.0);
-			add_noise(samples, blocksize, InputNoiseStdDev);
 			ProcessNewSamples(samples, blocksize);
 		}
 		ZF_LOGD("Done decoding %s.", DecodeWav[WavFileCount]);

--- a/src/common/ARDOPCommon.c
+++ b/src/common/ARDOPCommon.c
@@ -65,7 +65,6 @@ bool HWriteRxWav = false;  // Record RX controlled by host command RECRX
 bool WriteRxWav = false;  // Record RX controlled by Command line/TX/Timer
 bool WriteTxWav = false;  // Record TX
 bool UseSDFT = false;
-bool FixTiming = true;
 bool WG_DevMode = false;
 // the --decodewav option can be repeated to provide the pathnames of multiple
 // WAV files to be decoded.  If more are given than DecodeWav can hold, then the
@@ -313,7 +312,6 @@ static struct option long_options[] =
 	{"writetxwav",  no_argument, 0, 'T'},
 	{"decodewav",  required_argument, 0, 'd'},
 	{"sdft", no_argument, 0, 's'},
-	{"ignorealsaerror", no_argument, 0, 'A'},
 	{"help",  no_argument, 0 , 'h'},
 	{ NULL , no_argument , NULL , no_argument }
 };
@@ -377,9 +375,6 @@ char HelpScreen[] =
 	"-d pathname or --decodewav pathname  Pathname of WAV file to decode instead of listening.\n"
 	"                                       Repeat up to 5 times for multiple WAV files.\n"
 	"-s or --sdft                         Use the alternative Sliding DFT based 4FSK decoder.\n"
-	"-A or --ignorealsaerror              Ignore ALSA config error that causes timing error.\n"
-	"                                       DO NOT use -A option except for testing/debugging,\n"
-	"                                       or if ardopcf fails to run and suggests trying this.\n"
 	"\n"
 	" CAT and RTS/DTR PTT can share the same port.\n"
 	" See the ardopcf documentation for command line options at\n"
@@ -438,7 +433,7 @@ int processargs(int argc, char * argv[]) {
 	}
 
 	// Starting optstring with : prevents getopt_long() from printing errors
-	char optstring[64] = ":i:o:l:H:mc:p:k:u:G:hLRyzwTd:sA";
+	char optstring[64] = ":i:o:l:H:mc:p:k:u:G:hLRyzwTd:s";
 #ifdef LOG_OUTPUT_SYSLOG
 	// -S is only a valid option on Linux systems
 	snprintf(optstring + strlen(optstring), sizeof(optstring), "S");
@@ -724,10 +719,6 @@ int processargs(int argc, char * argv[]) {
 
 			case 's':
 				UseSDFT = true;
-				break;
-
-			case 'A':
-				FixTiming = false;
 				break;
 
 			case ':':

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -1109,8 +1109,6 @@ void ProcessUnconnectedConReqFrame(int intFrameType, UCHAR * bytData)
 
 }
 
-extern int extraDelay;
-
 // This is the main subroutine for processing ARQ frames
 
 void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, bool blnFrameDecodedOK)
@@ -1121,14 +1119,11 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, bool 
 	static UCHAR * strCallsign;
 	int intReportedLeaderMS = 0;
 	char HostCmd[80];
-	int timeSinceDecoded = Now - DecodeCompleteTime;
 
-	// Allow for link turnround before responding
-
-	ZF_LOGD("Time since received = %d", timeSinceDecoded);
-
-	if (timeSinceDecoded < 250 + extraDelay)
-		txSleep((250 + extraDelay) - timeSinceDecoded);
+	// Sleep() was formerly used here to ensure that there was a sufficient
+	// minimum delay between a received frame and the transmitted response.
+	// This delay is now handled with txSleep() in initFilter(), which is called
+	// while preparing to transmit.
 
 	// Note this is called as part of the RX sample poll routine
 

--- a/src/common/SoundInput.c
+++ b/src/common/SoundInput.c
@@ -1193,6 +1193,10 @@ void ProcessNewSamples(short * Samples, int nSamples) {
 			{
 				// Frame has no data so is now complete
 				frameLen = 0;
+				// DecodeCompleteTime is used in initFilter() to ensure that
+				// there is a sufficient minimum delay between the end of a
+				// received frame, and the sending of a response.
+				DecodeCompleteTime = Now;
 
 				// See if IRStoISS shortcut can be invoked
 
@@ -1215,7 +1219,11 @@ void ProcessNewSamples(short * Samples, int nSamples) {
 				{
 					// In this state transition to ISS if  ACK frame
 
-					txSleep(250);
+					// Sleep() was formerly used here to ensure that there was
+					// a sufficient minimum delay between a received frame and
+					// the transmitted response.  This delay is now handled with
+					// txSleep() in initFilter(), which is called while
+					// preparing to transmit.
 
 					ZF_LOGI("[ARDOPprotocol.ProcessNewSamples] ProtocolState=IRStoISS, substate = %s ACK received. Cease BREAKS, NewProtocolState=ISS, substate ISSData", ARQSubStates[ARQState]);
 					blnEnbARQRpt = false;  // stop the BREAK repeats
@@ -1241,8 +1249,6 @@ void ProcessNewSamples(short * Samples, int nSamples) {
 				State = SearchingForLeader;
 				blnFrameDecodedOK = true;
 				ZF_LOGI("[DecodeFrame] Frame: %s ", Name(intFrameType));
-
-				DecodeCompleteTime = Now;
 
 				goto ProcessFrame;
 			}

--- a/src/linux/ALSA.c
+++ b/src/linux/ALSA.c
@@ -46,8 +46,6 @@ short inbuffer[2][ReceiveSize];  // Two buffers of 0.1 Sec duration for RX audio
 int Index = 0;  // buffer being used 0 or 1
 int inIndex = 0;  // inbuffer being used 0 or 1
 
-snd_pcm_sframes_t MaxAvail;
-
 snd_pcm_t *	playhandle = NULL;
 snd_pcm_t *	rechandle = NULL;
 
@@ -306,172 +304,724 @@ nextcard:
 }
 
 
-bool FirstOpenSoundPlayback = true;  // used to only log warning about -A option once.
+// This function and log_all_pcm_hw_params_final() which are called by
+// open_audio() are not required for correct operation.  However, they are
+// useful for debugging problems related to audio device configuration.
+//
+// This function writes the full range of parameters supported by an audio
+// device before it has been configured, which may be useful to diagnose
+// problems configuring that device.
+void log_all_pcm_hw_params_multi(snd_pcm_hw_params_t *params) {
+	int err;
+	unsigned int channels_min, channels_max;
+	char em[] = "##############################";
+	// This function should do nothing unless ZF_LOGV() will write to console
+	// or log file.
+	if (!ZF_LOG_ON_VERBOSE)
+		return;
 
-bool OpenSoundPlayback(char * PlaybackDevice) {
-	unsigned int intRate;  // reported number of frames per second
-	unsigned int intPeriodTime = 0;  // reported duration of one period in microseconds.
-	snd_pcm_uframes_t periodSize = 0;  // reported number of frames per period
-	int intDir;
-	int err = 0;
-	char buf1[100];
-	char * ptr;
-
-	if (strcmp(PlaybackDevice, "NOSOUND") == 0)
-		// For testing/diagnostic purposes, NOSOUND uses no audio device,
-		return true;
-
-	// Choose the number of frames per period.  This avoids possible ALSA misconfiguration
-	// errors that may result in a TX symbol timing error if the default value is accepted.
-	// The value chosen is a tradeoff between avoiding excessive CPU load caused by too
-	// small of a value and increased latency associated with too large a value.
-	// TODO: Consider alternate methods of choosing this value
-	snd_pcm_uframes_t setPeriodSize = m_sampleRate / 100;
-
-	if (playhandle) {
-		snd_pcm_close(playhandle);
-		playhandle = NULL;
+	ZF_LOGV("log_all_pcm_hw_params_multi()");
+	if ((err = snd_pcm_hw_params_get_channels_min(params, &channels_min)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_channels_min() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_channels_min() -> channels_min=%u",
+			channels_min);
 	}
-	strcpy(buf1, PlaybackDevice);
-	if ((ptr = strchr(buf1, ' ')) != NULL)
-		*ptr = 0;  // Get Device part of name
-
-	snd_pcm_hw_params_t *hw_params;
-
-	if ((err = snd_pcm_open(&playhandle, buf1, SND_PCM_STREAM_PLAYBACK, SND_PCM_NONBLOCK)) < 0) {
-		ZF_LOGE("cannot open playback audio device %s (%s)",  buf1, snd_strerror(err));
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_malloc (&hw_params)) < 0) {
-		ZF_LOGE("cannot allocate hardware parameter structure (%s)", snd_strerror(err));
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_any (playhandle, hw_params)) < 0) {
-		ZF_LOGE("cannot initialize hardware parameter structure (%s)", snd_strerror(err));
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_set_access (playhandle, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED)) < 0) {
-		ZF_LOGE("cannot set playback access type (%s)", snd_strerror(err));
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_set_format (playhandle, hw_params, SND_PCM_FORMAT_S16_LE)) < 0) {
-		ZF_LOGE("cannot set playback sample format S16_LE (%s)", snd_strerror(err));
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_set_rate (playhandle, hw_params, m_sampleRate, 0)) < 0) {
-		ZF_LOGE("cannot set playback sample rate (%s)", snd_strerror(err));
-		return false;
+	if ((err = snd_pcm_hw_params_get_channels_max(params, &channels_max)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_channels_max() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_channels_max() -> channels_max=%u",
+			channels_max);
 	}
 
-	if ((err = snd_pcm_hw_params_set_channels (playhandle, hw_params, m_playchannels)) < 0) {
-		ZF_LOGE("cannot set playback channel count to %d (%s)", m_playchannels, snd_strerror(err));
+	unsigned int approx_rate_min, approx_rate_max;
+	int rate_min_dir, rate_max_dir;
+	if ((err = snd_pcm_hw_params_get_rate_min(params, &approx_rate_min, &rate_min_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_rate_min() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_rate_min() -> approx_rate_min=%u (Hz) rate_min_dir=%i",
+			approx_rate_min, rate_min_dir);
+	}
+	if ((err = snd_pcm_hw_params_get_rate_max(params, &approx_rate_max, &rate_max_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_rate_max() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_rate_max() -> approx_rate_max=%u (Hz) rate_max_dir=%i",
+			approx_rate_max, rate_max_dir);
+	}
+
+	unsigned int approx_period_time_min, approx_period_time_max;
+	int period_time_min_dir, period_time_max_dir;
+	if ((err = snd_pcm_hw_params_get_period_time_min(params, &approx_period_time_min, &period_time_min_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_period_time_min() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_period_time_min() -> approx_period_time_min=%u (us) period_time_min_dir=%i",
+			approx_period_time_min, period_time_min_dir);
+	}
+	if ((err = snd_pcm_hw_params_get_period_time_max(params, &approx_period_time_max, &period_time_max_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_period_time_max() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_period_time_max() -> approx_period_time_max=%u (us) period_time_max_dir=%i",
+			approx_period_time_max, period_time_max_dir);
+	}
+
+	snd_pcm_uframes_t approx_period_size_min, approx_period_size_max;
+	int period_size_min_dir, period_size_max_dir;
+	if ((err = snd_pcm_hw_params_get_period_size_min(params, &approx_period_size_min, &period_size_min_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_period_size_min() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_period_size_min() -> approx_period_size_min=%lu (frames) period_size_min_dir=%i",
+			approx_period_size_min, period_size_min_dir);
+	}
+	if ((err = snd_pcm_hw_params_get_period_size_max(params, &approx_period_size_max, &period_size_max_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_period_size_max() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_period_size_max() -> approx_period_size_max=%lu (frames) period_size_max_dir=%i",
+			approx_period_size_max, period_size_max_dir);
+	}
+
+	unsigned int approx_periods_min, approx_periods_max;
+	int periods_min_dir, periods_max_dir;
+	if ((err = snd_pcm_hw_params_get_periods_min(params, &approx_periods_min, &periods_min_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_periods_min() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_periods_min() -> approx_periods_min=%u (per buffer) periods_min_dir=%i",
+			approx_periods_min, periods_min_dir);
+	}
+	if ((err = snd_pcm_hw_params_get_periods_max(params, &approx_periods_max, &periods_max_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_periods_max() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_periods_max() -> approx_periods_max=%u (per buffer) periods_max_dir=%i",
+			approx_periods_max, periods_max_dir);
+	}
+
+	unsigned int approx_buffer_time_min, approx_buffer_time_max;
+	int buffer_time_min_dir, buffer_time_max_dir;
+	if ((err = snd_pcm_hw_params_get_buffer_time_min(params, &approx_buffer_time_min, &buffer_time_min_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_buffer_time_min() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_buffer_time_min() -> approx_buffer_time_min=%u (us) buffer_time_min_dir=%i",
+			approx_buffer_time_min, buffer_time_min_dir);
+	}
+	if ((err = snd_pcm_hw_params_get_buffer_time_max(params, &approx_buffer_time_max, &buffer_time_max_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_buffer_time_max() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_buffer_time_max() -> approx_buffer_time_max=%u (us) buffer_time_max_dir=%i",
+			approx_buffer_time_max, buffer_time_max_dir);
+	}
+
+	snd_pcm_uframes_t buffer_size_min, buffer_size_max;
+	if ((err = snd_pcm_hw_params_get_buffer_size_min(params, &buffer_size_min)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_buffer_size_min() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_buffer_size_min() -> buffer_size_min=%lu (frames)",
+			buffer_size_min);
+	}
+	if ((err = snd_pcm_hw_params_get_buffer_size_max(params, &buffer_size_max)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_buffer_size_max() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_buffer_size_max() -> buffer_size_max=%lu (frames)",
+			buffer_size_max);
+	}
+}
+
+// This function and log_all_pcm_hw_params_multi() which are called by
+// open_audio() are not required for correct operation.  However, they are
+// useful for debugging problems related to audio device configuration.
+//
+// This function writes the parameters being used by a configured audio device,
+// which may be useful to diagnose problems configuring that device.
+void log_all_pcm_hw_params_final(snd_pcm_t *handle, snd_pcm_hw_params_t *params) {
+	int err;
+	unsigned int rate_num, rate_den;
+	char em[] = "##############################";
+	// This function should do nothing unless ZF_LOGV() will write to console
+	// or log file.
+	if (!ZF_LOG_ON_VERBOSE)
+		return;
+
+	ZF_LOGV("log_all_pcm_hw_params_final()");
+	if ((err = snd_pcm_hw_params_get_rate_numden(params, &rate_num, &rate_den)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_rate_numden() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_rate_numden() -> rate_num=%u (Hz) rate_den=%u",
+			rate_num, rate_den);
+	}
+
+	int sbits = snd_pcm_hw_params_get_sbits(params);
+	ZF_LOGV("snd_pcm_hw_params_get_sbits()=%i", sbits);
+
+	int fifo_size = snd_pcm_hw_params_get_fifo_size(params);
+	ZF_LOGV("snd_pcm_hw_params_get_fifo_size()=%i", fifo_size);
+
+	snd_pcm_access_t access;
+	if ((err = snd_pcm_hw_params_get_access(params, &access)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_access() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_access() -> access=%u (expect"
+			" SND_PCM_ACCESS_RW_INTERLEAVED=%u)",
+			access, SND_PCM_ACCESS_RW_INTERLEAVED);
+	}
+
+	snd_pcm_format_t format;
+	if ((err = snd_pcm_hw_params_get_format(params, &format)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_format() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_format() -> format=%u (expect"
+		" SND_PCM_FORMAT_S16_LE=%u)",
+		format, SND_PCM_FORMAT_S16_LE);
+	}
+
+	snd_pcm_subformat_t subformat;
+	if ((err = snd_pcm_hw_params_get_subformat(params, &subformat)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_subformat() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_subformat() -> subformat=%u (expect"
+		" SND_PCM_SUBFORMAT_STD=%u)",
+		subformat, SND_PCM_SUBFORMAT_STD);
+	}
+
+	unsigned int channels;
+	if ((err = snd_pcm_hw_params_get_channels(params, &channels)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_channels() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_channels() -> channels=%u", channels);
+	}
+
+	unsigned int approx_rate;
+	int rate_dir;
+	if ((err = snd_pcm_hw_params_get_rate(params, &approx_rate, &rate_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_rate() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_rate() -> approx_rate=%u (Hz) rate_dir=%i",
+			approx_rate, rate_dir);
+	}
+	if (rate_dir != 0 || rate_num / rate_den != approx_rate) {
+		ZF_LOGV("%s\nWARNING: sample rate may be inexact.  rate_num=%u (Hz),"
+			" rate_den=%u, so rate_num/rate_den=%f (Hz). approx_rate=%u (Hz),"
+			" rate_dir=%i\n%s",
+			em, rate_num, rate_den, 1.0 * rate_num / rate_den, approx_rate,
+			rate_dir, em);
+	}
+
+	unsigned int resample;
+	if ((err = snd_pcm_hw_params_get_rate_resample(handle, params, &resample)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_rate_resample() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_rate_resample() -> resample=%u (bool)",
+			resample);
+	}
+
+	unsigned int export_buffer;
+	if ((err = snd_pcm_hw_params_get_export_buffer(handle, params, &export_buffer)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_export_buffer() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_export_buffer() -> export_buffer=%u (bool)",
+			export_buffer);
+	}
+
+	unsigned int period_wakeup;
+	if ((err = snd_pcm_hw_params_get_period_wakeup(handle, params, &period_wakeup)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_period_wakeup() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_period_wakeup() -> period_wakeup=%u (bool)",
+			period_wakeup);
+	}
+
+	unsigned int approx_period_time, approx_period_time_max, approx_period_time_min;
+	int period_time_dir, period_time_dir_max, period_time_dir_min;
+	if ((err = snd_pcm_hw_params_get_period_time(params, &approx_period_time, &period_time_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_period_time() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_period_time() -> approx_period_time=%u (us) period_time_dir=%i",
+			approx_period_time, period_time_dir);
+	}
+	if (period_time_dir != 0) {
+		ZF_LOGV("%s\nWARNING: (period_time_dir=%i) != 0.  So, approx_period_time=%u"
+			" is inexact and it will be impossible to confirm consistency of"
+			" sample rate, period size, and period time.\n%s",
+			em, period_time_dir, approx_period_time, em);
+		if ((err = snd_pcm_hw_params_get_period_time_min(params, &approx_period_time_min, &period_time_dir_min)) < 0) {
+			ZF_LOGV("%s\n  Error from snd_pcm_hw_params_get_period_time_min() (%s)\n%s",
+				em, snd_strerror(err), em);
+		} else {
+			ZF_LOGV("  snd_pcm_hw_params_get_period_time_min() -> approx_period_time_min=%u (us) period_time_min_dir=%i",
+				approx_period_time_min, period_time_dir_min);
+		}
+		if ((err = snd_pcm_hw_params_get_period_time_max(params, &approx_period_time_max, &period_time_dir_max)) < 0) {
+			ZF_LOGV("%s\n  Error from snd_pcm_hw_params_get_period_time_max() (%s)\n%s",
+				em, snd_strerror(err), em);
+		} else {
+			ZF_LOGV("  snd_pcm_hw_params_get_period_time_max() -> approx_period_time_max=%u (us) period_time_max_dir=%i",
+				approx_period_time_max, period_time_dir_max);
+		}
+	}
+
+
+	snd_pcm_uframes_t approx_period_size, approx_period_size_min, approx_period_size_max;
+	int period_size_dir, period_size_dir_min, period_size_dir_max;
+	if ((err = snd_pcm_hw_params_get_period_size(params, &approx_period_size, &period_size_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_period_size() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_period_size() -> approx_period_size=%lu (frames) period_size_dir=%i",
+			approx_period_size, period_size_dir);
+	}
+	if (period_size_dir != 0) {
+		ZF_LOGV("%s\nWARNING: (period_size_dir=%i) != 0.  So, approx_period_size=%lu"
+			" is inexact and it will be impossible to confirm consistency of"
+			" sample rate, period size, and period time.\n%s",
+			em, period_size_dir, approx_period_size, em);
+		if ((err = snd_pcm_hw_params_get_period_size_min(params, &approx_period_size_min, &period_size_dir_min)) < 0) {
+			ZF_LOGV("%s\n  Error from snd_pcm_hw_params_get_period_size_min() (%s)\n%s",
+				em, snd_strerror(err), em);
+		} else {
+			ZF_LOGV("  snd_pcm_hw_params_get_period_size_min() -> approx_period_size_min=%lu (us) period_size_min_dir=%i",
+				approx_period_size_min, period_size_dir_min);
+		}
+		if ((err = snd_pcm_hw_params_get_period_size_max(params, &approx_period_size_max, &period_size_dir_max)) < 0) {
+			ZF_LOGV("%s\n  Error from snd_pcm_hw_params_get_period_size_max() (%s)\n%s",
+				em, snd_strerror(err), em);
+		} else {
+			ZF_LOGV("  snd_pcm_hw_params_get_period_size_max() -> approx_period_size_max=%lu (us) period_size_max_dir=%i",
+				approx_period_size_max, period_size_dir_max);
+		}
+	}
+
+	unsigned int approx_periods, approx_periods_max, approx_periods_min;
+	int periods_dir, periods_dir_max, periods_dir_min;
+	if ((err = snd_pcm_hw_params_get_periods(params, &approx_periods, &periods_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_periods() (%s)\n"
+			"This shouldn't happen unless periods has not been set. "
+			" However, sometimes it does.  So, get and max and min values",
+			em, snd_strerror(err));
+		if ((err = snd_pcm_hw_params_get_periods_min(params, &approx_periods_min, &periods_dir_min)) < 0) {
+			ZF_LOGV("%s\n  Error from snd_pcm_hw_params_get_periods_min() (%s)\n%s",
+				em, snd_strerror(err), em);
+		} else {
+			ZF_LOGV("  snd_pcm_hw_params_get_periods_min() -> approx_min_periods=%u (per buffer) periods_dir=%i",
+				approx_periods_min, periods_dir_min);
+		}
+		if ((err = snd_pcm_hw_params_get_periods_max(params, &approx_periods_max, &periods_dir_max)) < 0) {
+			ZF_LOGV("%s\n  Error from snd_pcm_hw_params_get_periods_max() (%s)\n%s",
+				em, snd_strerror(err), em);
+		} else {
+			ZF_LOGV("  snd_pcm_hw_params_get_periods_max() -> approx_max_periods=%u (per buffer) periods_dir=%i",
+				approx_periods_max, periods_dir_max);
+		}
+		ZF_LOGV("%s", em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_periods() -> approx_periods=%u (per buffer) periods_dir=%i",
+			approx_periods, periods_dir);
+	}
+
+	unsigned int approx_buffer_time;
+	int buffer_time_dir;
+	if ((err = snd_pcm_hw_params_get_buffer_time(params, &approx_buffer_time, &buffer_time_dir)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_buffer_time() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_buffer_time() -> approx_buffer_time=%u (us) buffer_time_dir=%i",
+			approx_buffer_time, buffer_time_dir);
+	}
+
+	// Note that period size is approx, but buffer size is exact.
+	snd_pcm_uframes_t buffer_size;
+	if ((err = snd_pcm_hw_params_get_buffer_size(params, &buffer_size)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_buffer_size() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_buffer_size() -> buffer_size=%lu (frames)",
+			buffer_size);
+	}
+
+	// ??
+	snd_pcm_uframes_t min_align;
+	if ((err = snd_pcm_hw_params_get_min_align(params, &min_align)) < 0) {
+		ZF_LOGV("%s\nError from snd_pcm_hw_params_get_min_align() (%s)\n%s",
+			em, snd_strerror(err), em);
+	} else {
+		ZF_LOGV("snd_pcm_hw_params_get_min_align() -> min_align=%lu",
+			min_align);
+	}
+
+
+	if (approx_period_time * approx_rate != approx_period_size * 1000000) {
+		if (period_time_dir == 0 && period_size_dir == 0) {
+			double calc_rate = (approx_period_size * 1000000.0) / approx_period_time;
+			ZF_LOGV("%s\n%s\nERROR: Inconsistent audio settings.\n"
+				"(period size * 1,000,000) / period time = sample rate.\n"
+				"(%i * 1,000,000) / %i = %.3f, but expected %i.\n"
+				"This is an error of about %.3fppm.\n%s\n%s",
+				em, em, (int) approx_period_size, approx_period_time,
+				calc_rate, approx_rate,
+				(calc_rate - approx_rate) / approx_rate * 1000000.0,
+				em, em);
+		} else if (period_time_dir != 0 && period_size_dir == 0) {
+			double calc_rate1 = (approx_period_size * 1000000.0) / approx_period_time;
+			double calc_rate2 = (approx_period_size * 1000000.0) / (approx_period_time + period_time_dir);
+			ZF_LOGV("%s\n%s\nERROR: Inconsistent audio settings.\n"
+				"Expect: (period size * 1,000,000) / period time = sample rate.\n"
+				"(%i * 1,000,000) / (%i or %i) = %.3f or %.3f.  Expected %i.\n"
+				"This is an error of about %.3f or %.3f ppm.\n%s\n%s",
+				em, em, (int) approx_period_size, approx_period_time,
+				approx_period_time + period_time_dir,
+				calc_rate1, calc_rate2, approx_rate,
+				(calc_rate1 - approx_rate) / approx_rate * 1000000.0,
+				(calc_rate2 - approx_rate) / approx_rate * 1000000.0,
+				em, em);
+		} else if (period_time_dir == 0 && period_size_dir != 0) {
+			double calc_rate1 = (approx_period_size * 1000000.0) / approx_period_time;
+			double calc_rate2 = ((approx_period_size + period_size_dir) * 1000000.0) / approx_period_time;
+			ZF_LOGV("%s\n%s\nERROR: Inconsistent audio settings.\n"
+				"Expect: (period size * 1,000,000) / period time = sample rate.\n"
+				"(%i * 1,000,000) / (%i or %i) = %.3f or %.3f.  Expected %i.\n"
+				"This is an error of about %.3f or %.3f ppm.\n%s\n%s",
+				em, em, (int) approx_period_size,
+				approx_period_time, approx_period_time + period_time_dir,
+				calc_rate1, calc_rate2, approx_rate,
+				(calc_rate1 - approx_rate) / approx_rate * 1000000.0,
+				(calc_rate2 - approx_rate) / approx_rate * 1000000.0,
+				em, em);
+		} else if (period_time_dir != 0 && period_size_dir != 0) {
+			double calc_rate1, calc_rate2;
+			if (period_time_dir == period_size_dir) {
+				calc_rate1 = (approx_period_size * 1000000.0) / (approx_period_time + period_time_dir);
+				calc_rate2 = ((approx_period_size + period_size_dir) * 1000000.0) / approx_period_time;
+			} else {
+				calc_rate1 = (approx_period_size * 1000000.0) / approx_period_time;
+				calc_rate2 = ((approx_period_size + period_size_dir) * 1000000.0)
+					/ (approx_period_time + period_time_dir);
+			}
+			ZF_LOGV("%s\n%s\nERROR: Inconsistent audio settings.\n"
+				"Expect: (period size * 1,000,000) / period time = sample rate.\n"
+				"((%i or %i) * 1,000,000) / (%i or %i) = %.3f or %.3f.  Expected %i.\n"
+				"This is an error of about %.3f or %.3f ppm.\n%s\n%s",
+				em, em, (int) approx_period_size, (int) approx_period_size + period_size_dir,
+				approx_period_time, approx_period_time + period_time_dir,
+				calc_rate1, calc_rate2, approx_rate,
+				(calc_rate1 - approx_rate) / approx_rate * 1000000.0,
+				(calc_rate2 - approx_rate) / approx_rate * 1000000.0,
+				em, em);
+		}
+	} else {
+		ZF_LOGV("Audio settings OK: %d * %d == %lu * 1000000.",
+			approx_period_time, approx_rate, approx_period_size);
+	}
+}
+
+
+// Open audio device.  If successful, return the handle to the configured
+// ALSA audio device.  Device is prepared, but not started.
+// On failure, return NULL.
+snd_pcm_t * open_audio(const char *devstr, bool iscapture, int ch) {
+	const int rate = 12000;  // Sample rate is always 12000 for ardopcf
+	int bsize = 24000;  // buffer size (near is OK) for buffer time of 2 seconds
+	int psize = 240;  // period size (near is OK)
+	int mode = iscapture ? SND_PCM_STREAM_CAPTURE : SND_PCM_STREAM_PLAYBACK;
+	char forstr[9];
+	//  bsize and psize of type required for snd_pcm functions
+	snd_pcm_uframes_t pcm_bsize = (snd_pcm_uframes_t) bsize;
+	snd_pcm_uframes_t pcm_psize = (snd_pcm_uframes_t) psize;
+
+	int period_size_dir = 0;
+
+	snd_pcm_t *handle;
+	int err;
+	snd_pcm_info_t *info;
+	const char *name = NULL;
+	snd_pcm_hw_params_t *params;
+	char em[] = "##############################";
+
+	snprintf(forstr, sizeof(forstr), "%s", iscapture ? "capture" : "playback");
+
+	if ((err = snd_pcm_open(&handle, devstr, mode, 0)) < 0) {
+		ZF_LOGE("Error opening audio device %s for %s (%s)",
+			devstr, forstr, snd_strerror(err));
+		return NULL;
+	}
+
+	if ((err = snd_pcm_info_malloc(&info)) < 0) {
+		ZF_LOGE("Error allocating audio info for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	if ((err = snd_pcm_info(handle, info)) < 0) {
+		ZF_LOGE("Error getting audio info for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_info_free(info);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	if ((name = snd_pcm_info_get_name(info)) == NULL) {
+		ZF_LOGE("Error getting name from audio info for %s.", forstr);
+		snd_pcm_info_free(info);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	ZF_LOGD("Opening audio device for %s with device name = %s",
+		forstr, name);
+	snd_pcm_info_free(info);
+	info = NULL;
+
+	if ((err = snd_pcm_hw_params_malloc(&params)) < 0) {
+		ZF_LOGE("Error allocating audio parameters for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	if ((err = snd_pcm_hw_params_any(handle, params)) < 0) {
+		ZF_LOGE("Error initializing audio parameters for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+
+	log_all_pcm_hw_params_multi(params);
+
+	// Set parameters
+	if ((err = snd_pcm_hw_params_set_access(handle, params, SND_PCM_ACCESS_RW_INTERLEAVED)) < 0) {
+		ZF_LOGE("Error setting audio access to interleaved read/write for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	snd_pcm_access_t access;
+	if ((err = snd_pcm_hw_params_get_access(params, &access)) < 0) {
+		ZF_LOGE("Error from snd_pcm_hw_params_get_access() for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	if (access != SND_PCM_ACCESS_RW_INTERLEAVED) {
+		ZF_LOGE("Tried to set access to %u (SND_PCM_ACCESS_RW_INTERLEAVED) for"
+			" %s but snd_pcm_hw_params_get_access() -> access=%u without"
+			" returning an error",
+			SND_PCM_ACCESS_RW_INTERLEAVED, forstr, access);
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+
+	// This explicitly sets data to be read/written as little-endian.  If this
+	// code is ever used on a big-endian machine, this may need to be changed.
+	if ((err = snd_pcm_hw_params_set_format(handle, params, SND_PCM_FORMAT_S16_LE)) < 0) {
+		ZF_LOGE("Error setting audio access to 16-bit LE for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	snd_pcm_format_t format;
+	if ((err = snd_pcm_hw_params_get_format(params, &format)) < 0) {
+		ZF_LOGE("Error from snd_pcm_hw_params_get_format() for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	if (format != SND_PCM_FORMAT_S16_LE) {
+		ZF_LOGE("Tried to set format to %u (SND_PCM_FORMAT_S16_LE) for %s but"
+			" snd_pcm_hw_params_get_format() -> format=%u without returning"
+			" an error",
+			SND_PCM_FORMAT_S16_LE, forstr, format);
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+
+	if ((err = snd_pcm_hw_params_set_channels(handle, params, ch)) < 0) {
+		ZF_LOGE("Error setting number of audio channels to %i for %s (%s)",
+			ch, forstr, snd_strerror(err));
 		if (m_playchannels  == 2) {
 			ZF_LOGE("The -%s command line option was used to indicate that the"
-				" %s channel of a stereo audio playback device should be used."
-				" However, the audio playback device specified (%s) could not be"
-				" opened as a two channel (stereo) device.  Try again without"
-				" the -%s command line option to open it as a single channel"
-				" (mono) device.",
-				UseLeftTX ? "y" : "z",
-				UseLeftTX ? "left" : "right",
-				PlaybackDevice,
-				UseLeftTX ? "y" : "z");
+				" %s channel of a stereo audio device should be used for %s."
+				" However, the audio playback device specified (%s) could not"
+				" be opened as a two channel (stereo) device.  Try again"
+				" without the -%s command line option to open it as a single"
+				" channel (mono) device.",
+				iscapture ? (UseLeftRX ? "L" : "R") : (UseLeftTX ? "y" : "z"),
+				(iscapture ? UseLeftTX : UseLeftRX) ? "left" : "right",
+				forstr,
+				iscapture ? CaptureDevice : PlaybackDevice,
+				iscapture ? (UseLeftRX ? "L" : "R") : (UseLeftTX ? "y" : "z"));
 			return false;
 		}
-		ZF_LOGE("Neither the -y nor -z command line option was used to indicate"
-			" that the specified audio playback device (%s) should be opened"
+		ZF_LOGE("Neither the %s command line option was used to indicate"
+			" that the specified %s audio device (%s) should be opened"
 			" as a stereo device, and to select which of its channels should be"
 			" used.  Thus, the device was opened as a single channel (mono)"
 			" audio device, but this failed.  This probably means that the"
 			" device can only be opened as a two channel (stereo) device.  So,"
-			" please try again using either the -y or -z command line option to"
+			" please try again using either the %s command line option to"
 			" indicate which channel to use.",
-			PlaybackDevice);
+			iscapture ? "-L nor -R" : "-y nor -z",
+			forstr,
+			PlaybackDevice,
+			iscapture ? "-L or -R" : "-y or -z");
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	unsigned int channels;
+	if ((err = snd_pcm_hw_params_get_channels(params, &channels)) < 0) {
+		ZF_LOGE("Error from snd_pcm_hw_params_get_channels() for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	if ((int) channels != ch) {
+		ZF_LOGE("Tried to set channels to %u for %s but"
+			" snd_pcm_hw_params_get_channels() -> channels=%u without returning"
+			" an error",
+			ch, forstr, channels);
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+
+	if ((err = snd_pcm_hw_params_set_rate(handle, params, rate, 0)) < 0) {
+		ZF_LOGE("Error setting audio sample rate to %i (Hz) for %s (%s)\n",
+			rate, forstr, snd_strerror(err));
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	unsigned int approx_rate;
+	int rate_dir;
+	if ((err = snd_pcm_hw_params_get_rate(params, &approx_rate, &rate_dir)) < 0) {
+		ZF_LOGE("Error from snd_pcm_hw_params_get_rate() for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	if (rate_dir != 0) {
+		ZF_LOGW("%s\nWARNING: Tried to set sample rate to %u for %s but"
+			" snd_pcm_hw_params_get_rate() -> approx_rate=%u and rate_dir=%u"
+			" The non-zero rate_dir suggests that approx_rate is inexact.\n%s",
+			em, rate, forstr, approx_rate, rate_dir, em);
+		// While perhaps undesirable, this is not necessarily an error, so don't
+		// fail.
+	} else if ((int) approx_rate != rate) {
+		ZF_LOGE("Tried to set sample rate to %u for %s but"
+			" snd_pcm_hw_params_get_rate() -> approx_rate=%u and rate_dir=%u"
+			" without returning an error",
+			rate, forstr, approx_rate, rate_dir);
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+
+	// According to a comment dated 20200913 by "borine" at
+	// https://github.com/Arkq/bluez-alsa/issues/376:
+	// "It is not well documented, but when configuring the hardware params you
+	// should set the period size before setting the buffer size."
+	// Otherwise, snd_pcm_hw_params_get_periods() may fail with (Invalid argument)
+
+	if ((err = snd_pcm_hw_params_set_period_size_near(handle, params, &pcm_psize, &period_size_dir)) < 0) {
+		ZF_LOGE("Error setting period size to near %i (frames) for %s. (%s)",
+			psize, forstr, snd_strerror(err));
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	if (psize != (int) pcm_psize) {
+		ZF_LOGW("%s\nWARNING: Setting period_size near %i resulted in %i (frames)"
+			" for %s.\n%s",
+			em, psize, (int) pcm_psize, forstr, em);
+	}
+	psize = (int) pcm_psize;
+
+	if ((err = snd_pcm_hw_params_set_buffer_size_near(handle, params, &pcm_bsize)) < 0) {
+		ZF_LOGE("Error setting audio buffer size near %lu (frames) for %s (%s)",
+			pcm_bsize, forstr, snd_strerror(err));
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	if (bsize != (int) pcm_bsize) {
+		ZF_LOGW("%s\nWARNING: Setting buffer_size near %i resulted in %i (frames)"
+			" for %s \n%s",
+			em, bsize, (int) pcm_bsize, forstr, em);
+	}
+	bsize = (int) pcm_bsize;
+	ZF_LOGD("For %s: buffer_size = %i (frames) gives a buffer time of about %i ms.",
+		forstr, bsize, 1000 * bsize / rate);
+
+	if ((err = snd_pcm_hw_params(handle, params)) < 0) {
+		ZF_LOGE("Error setting audio parameters for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_hw_params_free(params);
+		snd_pcm_close(handle);
+		return NULL;
+	}
+
+	log_all_pcm_hw_params_final(handle, params);
+
+	snd_pcm_hw_params_free(params);
+	if ((err = snd_pcm_prepare(handle)) < 0) {
+		ZF_LOGE("Error preparing audio for %s (%s)",
+			forstr, snd_strerror(err));
+		snd_pcm_close(handle);
+		return NULL;
+	}
+	return handle;
+}
+
+
+bool FirstOpenSoundPlayback = true;  // used to only log warning about -A option once.
+
+bool OpenSoundPlayback(char * PlaybackDevice) {
+	if (strcmp(PlaybackDevice, "NOSOUND") == 0)
+		// For testing/diagnostic purposes, NOSOUND uses no audio device,
+		return true;
+
+	if (playhandle) {
+		snd_pcm_close(playhandle);
+		playhandle = NULL;
+		ZF_LOGE("ERROR: OpenSoundPlayback() called, but device already open.");
+		blnClosing = true;
 		return false;
 	}
 
-	if (FixTiming) {
-		if ((err = snd_pcm_hw_params_set_period_size (playhandle, hw_params, setPeriodSize, 0)) < 0) {
-			ZF_LOGE("cannot set playback period size (%s)", snd_strerror(err));
-			return false;
-		}
-	}
-
-	if ((err = snd_pcm_hw_params (playhandle, hw_params)) < 0) {
-		ZF_LOGE("cannot set parameters (%s)", snd_strerror(err));
-		return false;
-	}
-
-	// Verify that key values were set as expected
-	if ((err = snd_pcm_hw_params_get_rate(hw_params, &intRate, &intDir)) < 0) {
-		ZF_LOGE("cannot verify playback rate (%s)", snd_strerror(err));
-		return false;
-	}
-	if (m_sampleRate != intRate) {
-		ZF_LOGE("Unable to correctly set playback rate.  Got %d instead of %d.",
-			intRate, m_sampleRate);
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_get_period_size(hw_params, &periodSize, &intDir)) < 0) {
-		ZF_LOGE("cannot verify playback period size (%s)", snd_strerror(err));
-		return false;
-	}
-	if (FixTiming && (setPeriodSize != periodSize)) {
-		ZF_LOGE("Unable to correctly set playback period size.  Got %ld instead of %ld.",
-			periodSize, setPeriodSize);
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_get_period_time(hw_params, &intPeriodTime, &intDir)) < 0) {
-		ZF_LOGE("cannot verify playback period time (%s)", snd_strerror(err));
-		return false;
-	}
-	if (FixTiming && (intPeriodTime * intRate != periodSize * 1000000)) {
-		ZF_LOGE("\n\nERROR: Inconsistent playback settings: %d * %d != %lu *"
-			" 1000000.  Please report this error with a message to the ardop"
-			" users group at ardop.groups.io or by creating an issue at"
-			" github.com/pflarue/ardop.  You may find that ardopcf is usable"
-			" with your hardware/operating system by using the -A command line"
-			" option.\n\n",
-			intPeriodTime, intRate, periodSize);
-		return false;
-	}
-	// ZF_LOGI("snd_pcm_hw_params_get_period_time(hw_params, &intPeriodTime, &intDir) intPeriodTime=%d intDir=%d", intPeriodTime, intDir);
-
-	if (!FixTiming && (intPeriodTime * intRate != periodSize * 1000000) && FirstOpenSoundPlayback) {
-		ZF_LOGW("WARNING: Inconsistent ALSA playback configuration: %u * %u != %ld * 1000000.",
-			intPeriodTime, intRate, periodSize);
-		ZF_LOGW("This will result in a playblack sample rate of %f instead of %d.",
-			periodSize * 1000000.0 / intPeriodTime, intRate);
-		ZF_LOGW("This is an error of about %fppm.  Per the Ardop spec +/-100ppm"
-			" should work well and +/-1000 ppm should work with some"
-			" performance degredation.",
-			(intRate - (periodSize * 1000000.0 / intPeriodTime))/intRate * 1000000);
-		ZF_LOGW("\n\nWARNING: The -A option was specified.  So, ALSA"
-			" misconfiguration will be accepted and ignored.  This option is"
-			" primarily intended for testing/debuging.  However, it may also be"
-			" useful if ardopcf will not run without it.  In this case, please"
-			" report this problem to the ardop users group at ardop.groups.io"
-			" or by creating an issue at www.github.com/pflarue/ardop.\n\n");
-	}
-	FirstOpenSoundPlayback = false;
-	snd_pcm_hw_params_free(hw_params);
-
-	if ((err = snd_pcm_prepare (playhandle)) < 0) {
-		ZF_LOGE("cannot prepare audio interface for use (%s)", snd_strerror(err));
-		return false;
-	}
-
-	MaxAvail = snd_pcm_avail_update(playhandle);
+	playhandle = open_audio(PlaybackDevice, false, m_playchannels);
+	if (playhandle == NULL)
+		return false;  // Error already logged
 	return true;
 }
 
 
 bool OpenSoundCapture(char * CaptureDevice) {
-	int err = 0;
-	char buf1[100];
-	char * ptr;
-	snd_pcm_hw_params_t *hw_params;
-
+	int err;
 	if (strcmp(CaptureDevice, "NOSOUND") == 0)
 		// For testing/diagnostic purposes, NOSOUND uses no audio device,
 		return true;
@@ -479,89 +1029,307 @@ bool OpenSoundCapture(char * CaptureDevice) {
 	if (rechandle) {
 		snd_pcm_close(rechandle);
 		rechandle = NULL;
-	}
-
-	strcpy(buf1, CaptureDevice);
-
-	if ((ptr = strchr(buf1, ' ')) != NULL)
-		*ptr = 0;  // Get Device part of name
-
-	if ((err = snd_pcm_open (&rechandle, buf1, SND_PCM_STREAM_CAPTURE, 0)) < 0) {
-		ZF_LOGE("cannot open capture audio device %s (%s)", buf1, snd_strerror(err));
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_malloc (&hw_params)) < 0) {
-		ZF_LOGE("cannot allocate capture hardware parameter structure (%s)", snd_strerror(err));
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_any (rechandle, hw_params)) < 0) {
-		ZF_LOGE("cannot initialize capture hardware parameter structure (%s)", snd_strerror(err));
+		ZF_LOGE("ERROR: OpenSoundCapture() called, but device already open.");
+		blnClosing = true;
 		return false;
 	}
 
-	if ((err = snd_pcm_hw_params_set_channels (rechandle, hw_params, m_recchannels)) < 0) {
-		ZF_LOGE("cannot set capture channel count to %d (%s)", m_recchannels, snd_strerror(err));
-		if (m_recchannels  == 2) {
-			ZF_LOGE("The -%s command line option was used to indicate that the"
-				" %s channel of a stereo audio capture device should be used."
-				" However, the audio capture device specified (%s) could not be"
-				" opened as a two channel (stereo) device.  Try again without"
-				" the -%s command line option to open it as a single channel"
-				" (mono) device.",
-				UseLeftRX ? "L" : "R",
-				UseLeftRX ? "left" : "right",
-				CaptureDevice,
-				UseLeftRX ? "L" : "R");
-			return false;
-		}
-		ZF_LOGE("Neither the -L nor -R command line option was used to indicate"
-			" that the specified audio capture device (%s) should be opened"
-			" as a stereo device, and to select which of its channels should be"
-			" used.  Thus, the device was opened as a single channel (mono)"
-			" audio device, but this failed.  This probably means that the"
-			" device can only be opened as a two channel (stereo) device.  So,"
-			" please try again using either the -L or -R command line option to"
-			" indicate which channel to use.",
-			CaptureDevice);
+	rechandle = open_audio(CaptureDevice, true, m_recchannels);
+	if (rechandle == NULL)
+		return false;  // Error already logged
+	if ((err = snd_pcm_start(rechandle)) < 0) {
+		ZF_LOGE("Error starting audio for capture (%s)",
+			snd_strerror(err));
 		return false;
 	}
-
-	// craiger add frames per period
-	fpp = 600;
-	dir = 0;
-
-	if ((err = snd_pcm_hw_params_set_period_size_near (rechandle, hw_params, &fpp, &dir)) < 0) {
-		ZF_LOGE("snd_pcm_hw_params_set_period_size_near failed (%s)", snd_strerror(err));
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_set_access (rechandle, hw_params, SND_PCM_ACCESS_RW_INTERLEAVED)) < 0) {
-		ZF_LOGE("cannot set capture access type (%s)", snd_strerror(err));
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_set_format (rechandle, hw_params, SND_PCM_FORMAT_S16_LE)) < 0) {
-		ZF_LOGE("cannot set capture sample format S16_LE (%s)", snd_strerror(err));
-		return false;
-	}
-	if ((err = snd_pcm_hw_params_set_rate (rechandle, hw_params, m_sampleRate, 0)) < 0) {
-		ZF_LOGE("cannot set capture sample rate (%s)", snd_strerror(err));
-		return false;
-	}
-	if ((err = snd_pcm_hw_params (rechandle, hw_params)) < 0) {
-		ZF_LOGE("cannot set parameters (%s)", snd_strerror(err));
-		return false;
-	}
-
-	snd_pcm_hw_params_free(hw_params);
-	if ((err = snd_pcm_prepare (rechandle)) < 0) {
-		ZF_LOGE("cannot prepare audio interface for use (%s)", snd_strerror(err));
-		return false;
-	}
-
-	snd_pcm_start(rechandle);  // without this avail stuck at 0
 	return true;
 }
 
-bool OpenSoundCard() {
+// Return true on success, false on failure
+bool attempt_recovery(bool iscapture, int snderr) {
+	bool opened;
+	snd_pcm_t ** handleptr = iscapture ? &rechandle : &playhandle;
+	if (snderr == -EPIPE && !iscapture) {
+		ZF_LOGV("A Broken Pipe error occured while attempting audio device"
+			" write.  For some sound devices such as ALSA dmix and its"
+			" derivatives, this occurs at the start of each transmission. "
+			" Attempting to recover.  The ALSA error in snd_pcm_recover() that"
+			" follows is related to this.");
+	} else {
+		ZF_LOGE("An error occured while attempting audio device %s.  %s. "
+			" Attempting to recover.",
+			iscapture ? "read" : "write",
+			snd_strerror(snderr));
+	}
+	if (snd_pcm_recover(*handleptr, snderr, 0) < 0) {
+		ZF_LOGE("Unable to recover.  Attempting to close and re-open audio"
+			" %s device.",
+			iscapture ? "capture" : "playback");
+		if (*handleptr != NULL) {
+			snd_pcm_close(*handleptr);
+			*handleptr = NULL;
+		}
+		if (iscapture)
+			opened = OpenSoundCapture(CaptureDevice);
+		else
+			opened = OpenSoundPlayback(PlaybackDevice);
+		if (!opened) {
+			// Unable to continue.
+			ZF_LOGE("Error re-opening audio %s device.",
+				iscapture ? "capture" : "playback");
+			blnClosing = true;  // This is detected in the ardop main loop.
+			return false;
+		}
+	} else if (iscapture) {
+		// For a capture device, snd_pcm_avail() will always return 0 after
+		// successful recovery until snd_pcm_start() is called.
+		int err;
+		if ((err = snd_pcm_start(rechandle)) < 0) {
+			ZF_LOGE("Error restarting audio after snd_pcm_recover() for"
+				" capture device. (%s)",
+				snd_strerror(err));
+			blnClosing = true;  // This is detected in the ardop main loop.
+			return false;
+		}
+	}
+	return true;
+}
+
+
+// Write samples to a mono or stereo audio device.
+// Return nSamples (number of samples written) on success, or 0 on failure with
+// blnClosing also set to true.
+int PackSamplesAndSend(short * input, int nSamples) {
+	unsigned short samples[256000];
+	unsigned short * sampptr = samples;
+	int ret;
+
+	// Convert byte stream to int16 (watch endianness)
+	if (m_playchannels == 1) {
+		for (int n = 0; n < nSamples; ++n) {
+			*(sampptr++) = input[0];
+			input ++;
+		}
+	} else {
+		for (int n = 0; n < nSamples; n++) {
+			// Set left channel value
+			if (UseLeftTX)
+				*(sampptr++) = input[0];
+			else
+				*(sampptr++) = 0;
+
+			// Set right channel value
+			if (UseRightTX)
+				*(sampptr++) = input[0];
+			else
+				*(sampptr++) = 0;
+
+			input ++;
+		}
+	}
+
+	int errcount = 0;
+	while ((ret = snd_pcm_writei(playhandle, samples, nSamples)) < 0 && !blnClosing) {
+		if (++errcount > 10) {
+			ZF_LOGE("Exiting ardopcf due to repeated audio write errors..");
+			blnClosing = true;  // This is detected in the ardop main loop.
+			return 0;
+		}
+		if (!attempt_recovery(false, ret)) {
+			// Unable to recover. blnClosing set, Error message logged.
+			return 0;
+		}
+	}
+	return ret;
+}
+
+
+// Return nSamples (number of samples written) on success, or 0 on failure with
+// blnClosing also set to true.
+// Block until samples can be staged for playback, calling txSleep() while
+// waiting.
+int SoundCardWrite(short * input, unsigned int nSamples) {
+	snd_pcm_sframes_t avail;
+
+	if (playhandle == NULL) {
+		ZF_LOGE("ERROR: SoundCardWrite() called, but no audio playback device"
+			" is open.");
+		blnClosing = true;  // This is detected in the ardop main loop.
+		return 0;
+	}
+
+	int errcount = 0;
+	while ((avail = snd_pcm_avail(playhandle)) < nSamples && !blnClosing) {
+		if (avail >= 0 || avail == -EAGAIN) {
+			txSleep(100);  // Wait until samples can be staged for playback
+		} else {
+			// Error
+			if (++errcount > 10) {
+				ZF_LOGE("Exiting ardopcf due to repeated audio write errors..");
+				blnClosing = true;  // This is detected in the ardop main loop.
+				return 0;
+			}
+			if (!attempt_recovery(false, avail)) {
+				// Unable to recover. blnClosing set, Error message logged.
+				return 0;
+			}
+		}
+	}
+	return PackSamplesAndSend(input, nSamples);
+}
+
+int SoundCardRead(short * input, unsigned int nSamples) {
+	short samples[65536];
+	int n;
+	int ret;
+	int avail;
+	int start;
+
+	if (rechandle == NULL) {
+		ZF_LOGE("ERROR: SoundCardRead() called, but no audio capture device"
+			" is open.");
+		blnClosing = true;  // This is detected in the ardop main loop.
+		return 0;
+	}
+
+	int errcount = 0;
+	while ((avail = snd_pcm_avail(rechandle)) < (int) nSamples && !blnClosing) {
+		if (avail >= 0 || avail == -EAGAIN) {
+			return 0;  // Insufficient samples available.  Do nothing.
+		}
+		// An error occured.  Try to recover
+		if (++errcount > 10) {
+			ZF_LOGE("Exiting ardopcf due to repeated audio read errors..");
+			blnClosing = true;  // This is detected in the ardop main loop.
+			return 0;
+		}
+		if (!attempt_recovery(true, avail)) {
+			// Unable to recover. blnClosing set, Error message logged.
+			return 0;
+		}
+	}
+
+	errcount = 0;
+	while ((ret = snd_pcm_readi(rechandle, samples, nSamples)) < 0 && !blnClosing) {
+		if (++errcount > 10) {
+			ZF_LOGE("Exiting ardopcf due to repeated audio read errors.");
+			blnClosing = true;  // This is detected in the ardop main loop.
+			return 0;
+		}
+		if (!attempt_recovery(true, ret)) {
+			// Unable to recover. blnClosing set, Error message logged.
+			return 0;
+		}
+	}
+
+	if (m_recchannels == 1) {
+		for (n = 0; n < ret; n++) {
+			memcpy(input, samples, nSamples*sizeof(short));
+		}
+	} else {
+		if (UseLeftRX)
+			start = 0;
+		else
+			start = 1;
+
+		for (n = start; n < (ret * 2); n+=2) {  // return alternate
+			*(input++) = samples[n];
+		}
+	}
+	return ret;
+}
+
+// TODO: Consider calling SoundCardWrite() directly instead
+short * SendtoCard(int n) {
+	if (playhandle == NULL) {
+		ZF_LOGE("ERROR: SendtoCard() called, but no audio playback device"
+			" is open.");
+		// This error is likely to be repeated several times because blnClosing
+		// is not detected/acted upon until control returns to the ardop main
+		// loop after the end of this transmission.
+		blnClosing = true;
+	}
+
+	SoundCardWrite(&buffer[Index][0], n);
+	if (txwff != NULL)
+		WriteWav(&buffer[Index][0], n, txwff);
+	return &buffer[Index][0];
+}
+
+// This mininal error handler to be passed to snd_lib_error_set_handler()
+// prevents ALSA from printing errors directly to the console.  Instead,
+// write an appropriate log message.  This ensures that the error is
+// written to the log file, rather than only to the console.  It also prevents
+// undesirable console output when using the --syslog command line option.
+//
+// If it detects a rapid string of ALSA errors, it signals for ardopcf to exit
+// normally.  The scenario envisioned which will cause this is if a sound device
+// is (accidentally?) disconnected or otherwise fails.  TODO: If/when the
+// ability to stop and restart audio processing and change audio devices without
+// restarting ardopcf are implemented, a better course of action for such a
+// failure may be implemented.
+void alsa_errhandler(const char *file, int line, const char *function, int err, const char *fmt, ...) {
+	static unsigned int errtime = 0;  // ms resolution
+	static unsigned int errcount = 0;
+	(void) fmt;  // This prevents an unused variable warning.
+
+	if (blnClosing)
+		return;  // This avoids spamming the logger with excessive error msgs
+
+	if (Now - errtime > 2000) {
+		// It has been more than 2 seconds since the last error
+		errcount = 0;
+	}
+	errtime = Now;
+	errcount += 1;
+
+	if (strcmp(function, "snd_pcm_recover") == 0) {
+		// For some audio devices such as ALSA dmix and its derivatives, this
+		// occurs at the start of every transmission.  So, write this as ZF_LOGV
+		// rather than ZF_LOGE.
+		if (err) {
+			ZF_LOGV("ALSA Error at %s:%i %s(): %s", file, line, function, snd_strerror(err));
+		} else {
+			ZF_LOGV("ALSA Error at %s:%i %s()", file, line, function);
+		}
+	} else {
+		if (err) {
+			ZF_LOGE("ALSA Error at %s:%i %s(): %s", file, line, function, snd_strerror(err));
+		} else {
+			ZF_LOGE("ALSA Error at %s:%i %s()", file, line, function);
+		}
+	}
+	if (errcount > 10) {
+		ZF_LOGE("In response to a string of rapid ALSA errors.  Exit.");
+		blnClosing = true;  // This is detected in the ardop main loop.
+	}
+}
+
+bool InitSound() {
+	// Using hw: where plughw: is required seems to be a common mistake.  So,
+	// log a warning to help new users correct this problem.
+	if (strncmp(CaptureDevice, "hw:", 3) == 0) {
+		ZF_LOGW("WARNING: Use of %s as the audio capture device may cause"
+			" problems.  This will only work if that device natively"
+			" supports a 12 kHz sample rate, which most do not.  If ardopcf"
+			" seems to work as expected, you can ignore this warning.  If"
+			" it does not, try using plug%s instead.",
+			CaptureDevice, CaptureDevice);
+	}
+	if (strncmp(PlaybackDevice, "hw:", 3) == 0) {
+		ZF_LOGW("WARNING: Use of %s as the audio playback device may cause"
+			" problems.  This will only work if that device natively"
+			" supports a 12 kHz sample rate, which most do not.  If ardopcf"
+			" seems to work as expected, you can ignore this warning.  If"
+			" it does not, try using plug%s instead.",
+			PlaybackDevice, PlaybackDevice);
+	}
+
+	snd_lib_error_set_handler(alsa_errhandler);
+
+	GetInputDeviceCollection();
+	GetOutputDeviceCollection();
+
 	if (strcmp(CaptureDevice, "0") == 0
 		|| (atoi(CaptureDevice) > 0 && strlen(CaptureDevice) <= 2)
 	) {
@@ -608,215 +1376,18 @@ bool OpenSoundCard() {
 				PlaybackDevice);
 	}
 
-	strcpy(SavedPlaybackDevice, PlaybackDevice);  // Saved so we can reopen in error recovery
-	if (OpenSoundPlayback(PlaybackDevice)) {
-		// TODO: Reconsider closing playback device here
-		// Close playback device so it can be shared
-		if (playhandle) {
-			snd_pcm_close(playhandle);
-			playhandle = NULL;
-		}
-
-		strcpy(SavedCaptureDevice, CaptureDevice);  // Saved so we can reopen in error recovery
-		return OpenSoundCapture(CaptureDevice);
-	}
-	else
+	if (!OpenSoundPlayback(PlaybackDevice)) {
+		// OpenSoundPlayback() already logged an error message.
 		return false;
-}
-
-int PackSamplesAndSend(short * input, int nSamples) {
-	unsigned short samples[256000];
-	unsigned short * sampptr = samples;
-	int ret;
-
-	// Convert byte stream to int16 (watch endianness)
-	if (m_playchannels == 1) {
-		for (int n = 0; n < nSamples; ++n) {
-			*(sampptr++) = input[0];
-			input ++;
-		}
-	} else {
-		for (int n = 0; n < nSamples; n++) {
-			// Set left channel value
-			if (UseLeftTX)
-				*(sampptr++) = input[0];
-			else
-				*(sampptr++) = 0;
-
-			// Set right channel value
-			if (UseRightTX)
-				*(sampptr++) = input[0];
-			else
-				*(sampptr++) = 0;
-
-			input ++;
-		}
 	}
-
-	if ((ret = snd_pcm_writei(playhandle, samples, nSamples)) < 0) {
-		snd_pcm_recover(playhandle, ret, 1);
-		ret = snd_pcm_writei(playhandle, samples, nSamples);
+	if (!OpenSoundCapture(CaptureDevice)) {
+		// OpenSoundCapture() already logged an error message.
+		snd_pcm_close(playhandle);
+		return false;
 	}
-	snd_pcm_avail_update(playhandle);
-	return ret;
-}
-
-
-int SoundCardWrite(short * input, unsigned int nSamples) {
-	snd_pcm_sframes_t avail;
-
-	if (playhandle == NULL)
-		return 0;
-
-	// Stop Capture
-	if (rechandle) {
-		snd_pcm_close(rechandle);
-		rechandle = NULL;
-	}
-
-	if ((avail = snd_pcm_avail_update(playhandle)) < 0) {
-		if (avail != -32)
-			ZF_LOGD("Playback Avail Recovering from %s ..", snd_strerror((int)avail));
-		snd_pcm_recover(playhandle, avail, 1);
-
-		if ((avail = snd_pcm_avail_update(playhandle)) < 0)
-			ZF_LOGD("avail play after recovery returned %d", (int)avail);
-	}
-
-	while (avail < (int) nSamples) {
-		txSleep(100);
-		avail = snd_pcm_avail_update(playhandle);
-	}
-
-	return PackSamplesAndSend(input, nSamples);
-}
-
-int SoundCardRead(short * input, unsigned int nSamples) {
-	short samples[65536];
-	int n;
-	int ret;
-	int avail;
-	int start;
-
-	if (rechandle == NULL)
-		return 0;
-
-	if ((avail = snd_pcm_avail_update(rechandle)) < 0) {
-		ZF_LOGD("avail Recovering from %s ..", snd_strerror((int)avail));
-		if (rechandle) {
-			snd_pcm_close(rechandle);
-			rechandle = NULL;
-		}
-
-		OpenSoundCapture(SavedCaptureDevice);
-//		snd_pcm_recover(rechandle, avail, 0);
-		avail = snd_pcm_avail_update(rechandle);
-		ZF_LOGD("After avail recovery %d ..", avail);
-	}
-
-	if (avail < (int) nSamples)
-		return 0;
-
-	if ((ret = snd_pcm_readi(rechandle, samples, nSamples)) < 0) {
-		ZF_LOGE("RX Error %d", ret);
-//		snd_pcm_recover(rechandle, avail, 0);
-		if (rechandle) {
-			snd_pcm_close(rechandle);
-			rechandle = NULL;
-		}
-
-		OpenSoundCapture(SavedCaptureDevice);
-//		snd_pcm_recover(rechandle, avail, 0);
-		avail = snd_pcm_avail_update(rechandle);
-		ZF_LOGD("After Read recovery Avail %d ..", avail);
-		return 0;
-	}
-
-	if (m_recchannels == 1) {
-		for (n = 0; n < ret; n++) {
-			memcpy(input, samples, nSamples*sizeof(short));
-		}
-	} else {
-		if (UseLeftRX)
-			start = 0;
-		else
-			start = 1;
-
-		for (n = start; n < (ret * 2); n+=2) {  // return alternate
-			*(input++) = samples[n];
-		}
-	}
-	return ret;
-}
-
-// TODO: Consider calling SoundCardWrite() directly instead
-short * SendtoCard(int n) {
-	if (playhandle)
-		SoundCardWrite(&buffer[Index][0], n);
-	if (txwff != NULL)
-		WriteWav(&buffer[Index][0], n, txwff);
-	return &buffer[Index][0];
-}
-
-// This mininal error handler to be passed to snd_lib_error_set_handler()
-// prevents ALSA from printing errors directly to the console.  Instead,
-// write an appropriate log message.  This ensures that the error is
-// written to the log file, rather than only to the console.  It also prevents
-// undesirable console output when using the --syslog command line option.
-//
-// If it detects a rapid string of ALSA errors, it signals for ardopcf to exit
-// normally.  The scenario envisioned which will cause this is if a sound device
-// is (accidentally?) disconnected or otherwise fails.  TODO: If/when the
-// ability to stop and restart audio processing and change audio devices without
-// restarting ardopcf are implemented, a better course of action for such a
-// failure may be implemented.
-void alsa_errhandler(const char *file, int line, const char *function, int err, const char *fmt, ...) {
-	static unsigned int errtime = 0;  // ms resolution
-	static unsigned int errcount = 0;
-	(void) fmt;  // This prevents an unused variable warning.
-
-	if (Now - errtime > 2000) {
-		// It has been more than 2 seconds since the last error
-		errcount = 0;
-	}
-	errtime = Now;
-	errcount += 1;
-
-	if (err) {
-		ZF_LOGE("ALSA Error at %s:%i %s(): %s", file, line, function, snd_strerror(err));
-	} else {
-		ZF_LOGE("ALSA Error at %s:%i %s()", file, line, function);
-	}
-	if (errcount > 10) {
-		ZF_LOGE("In response to a string of rapid ALSA errors.  Exit.");
-		blnClosing = true;  // This is detected in the ardop main loop.
-	}
-}
-
-bool InitSound() {
-	// Using hw: where plughw: is required seems to be a common mistake.  So,
-	// log a warning to help new users correct this problem.
-	if (strncmp(CaptureDevice, "hw:", 3) == 0) {
-		ZF_LOGW("WARNING: Use of %s as the audio capture device may cause"
-			" problems.  This will only work if that device natively"
-			" supports a 12 kHz sample rate, which most do not.  If ardopcf"
-			" seems to work as expected, you can ignore this warning.  If"
-			" it does not, try using plug%s instead.",
-			CaptureDevice, CaptureDevice);
-	}
-	if (strncmp(PlaybackDevice, "hw:", 3) == 0) {
-		ZF_LOGW("WARNING: Use of %s as the audio playback device may cause"
-			" problems.  This will only work if that device natively"
-			" supports a 12 kHz sample rate, which most do not.  If ardopcf"
-			" seems to work as expected, you can ignore this warning.  If"
-			" it does not, try using plug%s instead.",
-			PlaybackDevice, PlaybackDevice);
-	}
-
-	snd_lib_error_set_handler(alsa_errhandler);
-	GetInputDeviceCollection();
-	GetOutputDeviceCollection();
-	return OpenSoundCard();
+	// Capturing is intialized to to be true at startup in ARDOPC.c.  It it were
+	// not, StartCapture() would be called here.
+	return true;  // Both audio devices successfully opened.
 }
 
 // Process any captured samples
@@ -836,13 +1407,7 @@ void PollReceivedSamples() {
 
 void StopCapture() {
 	Capturing = false;
-
-	if (strcmp(PlaybackDevice, "NOSOUND") == 0)
-		return;
-
-	// Stopcapture is only called when we are about to transmit, so use it to open plaback device. We don't keep
-	// it open all the time to facilitate sharing.
-	OpenSoundPlayback(SavedPlaybackDevice);
+	return;
 }
 
 // TODO: Enable CODEC host command to start/stop audio processing
@@ -875,7 +1440,7 @@ unsigned short * SoundInit() {
 }
 
 
-// Called at end of transmit
+// Called at end of transmit to block until all staged audio has been played.
 void SoundFlush() {
 	// Append Trailer then send remaining samples
 	int txlenMs = 0;
@@ -884,20 +1449,20 @@ void SoundFlush() {
 	SendtoCard(Number);
 
 	// Wait for tx to complete
+	//
+	// TODO: Can greater consistency be achieved by monitoring the tx audio
+	// buffer, as is done in windows/Waveform.c rather than relying on
+	// pttOnTime?  Would such an approach be consistent for all linux audio
+	// devices including plughw, dmix, and pulse?
+	//
 	// samples sent is is in SampleNo, time started in mS is in pttOnTime.
 	// calculate time to stop
 	txlenMs = SampleNo / 12 + 20;  // 12000 samples per sec. 20 mS TXTAIL
 	ZF_LOGD("Tx Time %d Time till end = %d", txlenMs, (pttOnTime + txlenMs) - Now);
 
-	if (strcmp(PlaybackDevice, "NOSOUND") != 0) {
-		while (Now < (pttOnTime + txlenMs))
-			usleep(2000);
+	if (strcmp(PlaybackDevice, "NOSOUND") != 0)
+		txSleep((pttOnTime + txlenMs) - Now);
 
-		if (playhandle) {
-			snd_pcm_close(playhandle);
-			playhandle = NULL;
-		}
-	}
 	SoundIsPlaying = false;
 
 	if (blnEnbARQRpt > 0 || blnDISCRepeating)  // Start Repeat Timer if frame should be repeated
@@ -915,7 +1480,6 @@ void SoundFlush() {
 		// txwfu = NULL;
 	// }
 
-	OpenSoundCapture(SavedCaptureDevice);
 	StartCapture();
 
 	if (WriteRxWav && !HWriteRxWav) {

--- a/src/linux/ALSA.c
+++ b/src/linux/ALSA.c
@@ -1395,8 +1395,18 @@ void PollReceivedSamples() {
 	if (SoundCardRead(&inbuffer[0][0], ReceiveSize) == 0)
 		return;  // No samples to process
 
-	if (Capturing)
+	if (Capturing) {
 		ProcessNewSamples(&inbuffer[0][0], ReceiveSize);
+	} else {
+		// PreprocessNewSamples() writes these samples to the RX wav
+		// file when specified, even though not Capturing.  This
+		// produces a time continuous Wav file which can be useful for
+		// diagnostic purposes.  In earlier versions of ardopcf, this
+		// RX wav file could not be time continuous due to the way that
+		// ALSA audio devices were opened, closed, and configured.
+		// If Capturing, this is called from ProcessNewSamples().
+		PreprocessNewSamples(&inbuffer[0][0], ReceiveSize);
+	}
 }
 
 

--- a/src/linux/ALSA.c
+++ b/src/linux/ALSA.c
@@ -21,8 +21,6 @@ extern bool UseRightRX;
 extern bool UseLeftTX;
 extern bool UseRightTX;
 
-extern bool FixTiming;
-
 extern char CaptureDevice[80];
 extern char PlaybackDevice[80];
 
@@ -996,9 +994,6 @@ snd_pcm_t * open_audio(const char *devstr, bool iscapture, int ch) {
 	}
 	return handle;
 }
-
-
-bool FirstOpenSoundPlayback = true;  // used to only log warning about -A option once.
 
 bool OpenSoundPlayback(char * PlaybackDevice) {
 	if (strcmp(PlaybackDevice, "NOSOUND") == 0)

--- a/src/linux/ALSA.h
+++ b/src/linux/ALSA.h
@@ -2,11 +2,35 @@
 
 #include <stdbool.h>
 
+// Write list of available audio devices (input and output) to log.
+// Open CaptureDevice and PlaybackDevice.
+// Return true on success or false on failure
 bool InitSound();
+
+// Stage for playback the contents (n samples) of the buffer returned by the
+// previous call to SendtoCard().  Return a new empty buffer.
+// This will block until samples can be staged.
 short * SendtoCard(int n);
+
+// Check for available received audio samples.  If samples are available and
+// in the Capturing state, call ProcessNewSamples() with them, returning once
+// ProcessNewSamples() has returned.  The Capturing state is enabled by
+// SoundFlush() which whould be called after all samples to be transmitted have
+// been staged with SendtoCard(), and is disabled by StopCapture() which should
+// be called when beginning to transmit.
 void PollReceivedSamples();
+
+// Disable the Capturing state.
 void StopCapture();
+
+// Get an initial empty buffer to be filled before the first call to
+// SendtoCard().  Each call to SendtoCard returns the next empty buffer to be
+// filled.
 unsigned short * SoundInit();
+
+// Adds a trailer to the audio samples that have been staged with SendtoCard,
+// and then blocks until all of the staged audio has been played.  Before
+// returning, it calls KeyPTT(false) and enables the Capturing state.
 void SoundFlush();
 
 extern char **PlaybackDevices;

--- a/src/windows/os_util.c
+++ b/src/windows/os_util.c
@@ -96,6 +96,10 @@ unsigned int getNow() {
 	// in ms from the start of the WAV file.
 	if (DecodeWav[0][0])
 		return WavNow;
+	// TODO: timeGetTime() returns the time in ms since windows was started.  As
+	// a 32-bit value, it resets 2^32 ms, which is about 50 days.  While this is
+	// unlikely to occur, something should be implemented to keep this
+	// from causing a problem.  See DecodeCompleteTime and other uses.
 	return timeGetTime();
 }
 

--- a/test/ardop/test_ARDOPCommon_processargs.c
+++ b/test/ardop/test_ARDOPCommon_processargs.c
@@ -78,7 +78,6 @@ extern char DecodeWav[5][256];
 extern bool WriteRxWav;
 extern bool WriteTxWav;
 extern bool UseSDFT;
-extern bool FixTiming;
 
 void close_tcpCAT();
 int processargs(int argc, char * argv[]);
@@ -243,7 +242,6 @@ void reset_defaults() {
 		DecodeWav[i][0] = 0x00;  // zero length null terminated string
 	}
 	UseSDFT = false;
-	FixTiming = true;
 }
 
 
@@ -2749,34 +2747,6 @@ static void test_processargs(void** state) {
 		// nstartstrings=3 + cmdstr + 2x info about using default audio devices
 		assert_int_equal(printindex, 5);
 		assert_true(UseSDFT);
-	}
-	reset_defaults();  // reset global variables changed by processargs
-	reset_printstrs();  // reset captured strings from last test
-	if (true) {
-		// --ignorealsaerror
-		int testargc = 2;
-		char *testargv[] = {"ardopcf", "--ignorealsaerror"};
-		ret = processargs(testargc, testargv);
-		//print_printstrs();
-		//__real_printf("%i: %s\n", printindex, printstrs[printindex]);
-		assert_int_equal(ret, 0);  // 0 = normal end
-		// nstartstrings=3 + cmdstr + 2x info about using default audio devices
-		assert_int_equal(printindex, 5);
-		assert_false(FixTiming);
-	}
-	reset_defaults();  // reset global variables changed by processargs
-	reset_printstrs();  // reset captured strings from last test
-	if (true) {
-		// -A
-		int testargc = 2;
-		char *testargv[] = {"ardopcf", "-A"};
-		ret = processargs(testargc, testargv);
-		//print_printstrs();
-		//__real_printf("%i: %s\n", printindex, printstrs[printindex]);
-		assert_int_equal(ret, 0);  // 0 = normal end
-		// nstartstrings=3 + cmdstr + 2x info about using default audio devices
-		assert_int_equal(printindex, 5);
-		assert_false(FixTiming);
 	}
 	reset_defaults();  // reset global variables changed by processargs
 	reset_printstrs();  // reset captured strings from last test


### PR DESCRIPTION
Major refactoring of code to open and configure ALSA audio devices for Linux.  These changes should allow true ALSA hardware devices, standard ALSA plugins such as plughw, custom configured ALSA plugins for sharing audio devices between programs, and the `pulse` ALSA software device to all work more reliably.

As a part of this change, the ALSA audio devices are not longer closed/opened during transition between TX/RX.  This will make other planned improvements easier to do.  It also allowed refactoring of the functions for diagnostic recording received audio so that these recordings are now time continuous.

Documentation is updated to describe these changes and provide instructions for use of mix, snoop, and pulse audio devices.  An example .asoundrc file is included and referenced in the documentation.