### PR TITLE
Fix bug that produced wrong STATUS for failure to connect

### DIFF
--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -411,7 +411,7 @@ bool GetNextARQFrame()
 			displayCall(0x20, "");
 			wg_send_rcall(0, "");
 
-			if (!stationid_ok(&ARQStationRemote))
+			if (stationid_ok(&ARQStationRemote))
 			{
 				ZF_LOGI("[STATUS: CONNECT TO %s FAILED]", ARQStationRemote.str);
 				snprintf(HostCmd, sizeof(HostCmd), "STATUS CONNECT TO %s FAILED!", ARQStationRemote.str);


### PR DESCRIPTION
A bug was reported by John Wiseman at https://ardop.groups.io/g/users/topic/incompatibility_between/111289725.  This caused ardopcf to produce the host message "STATUS END ARQ CALL" instead of "STATUS CONNECT TO XXXXX FAILED!" when ardopcf fails to connect to a remote station.

This single byte change corrects that bug.