### PR TITLE
Apply a temporary fix for compatibility with beta firmware for the QRPLabs QMX

### DIFF
--- a/src/common/Modulate.c
+++ b/src/common/Modulate.c
@@ -695,7 +695,9 @@ void initFilter(int Width, int Centre)
 
 	DMABuffer = SoundInit();
 
-	KeyPTT(true);
+	// TEMPORARY FIX FOR COMPATIBILITY WITH QMX BETA SSB FIRMWARE
+	//  KeyPTT(true);
+	/////////////////////////////////////////////////////////////
 
 	SoundIsPlaying = true;
 	StopCapture();
@@ -718,6 +720,10 @@ void initFilter(int Width, int Centre)
 	// interacts with leader length adjusments based on data exchanged during
 	// ARQ handshake.
 	txSleep(250 + extraDelay - (Now - DecodeCompleteTime));
+
+	// TEMPORARY FIX FOR COMPATIBILITY WITH QMX BETA SSB FIRMWARE
+	KeyPTT(true);
+	/////////////////////////////////////////////////////////////
 
 	// pttOnTime is used to in linux/ALSA.c to calculate when enough time has
 	// elapsed for the audio to have been fully played before KeyPTT(false).


### PR DESCRIPTION
The Beta firmware 1_01_003 for the [QRPLabs](https://qrp-labs.com) QMX and QMX+ has a known issue causing PTT to disengage in USB mode if there is a pause in USB audio being sent.  This minor change provides a workaround to avoid doing that.  Since I believe that the code without this workaround will produce better results for some other radios, I expect to revert this change when the QMX firmware is fixed.

However, I'm including this fix in the ardopcf develop branch for now since I'm using the QMX for some on the air testing, and I think that with the new capabilities provided by the beta firmware, the QMX and QMX+ are very well suited to use ardopcf for low powered HF digital communications.  So, I hope that others will also try it.