### PR TITLE
List ptt devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,7 @@ test/ardop/test_log: OBJS := \
 test/ardop/test_log: WRAP := fopen fclose fwrite fflush freopen
 test/ardop/test_ARDOPCommon_processargs: WRAP := \
 	printf puts ardop_log_start InitAudio \
+	GetCM108Strlist GetSerialStrlist updateWebGuiNonAudioConfig \
 	OpenCOMPort tcpconnect OpenCM108 OpenSoundCapture OpenSoundPlayback \
 
 -include *.d

--- a/lib/ws_server/ws_server.c
+++ b/lib/ws_server/ws_server.c
@@ -1139,7 +1139,7 @@ int client_handler(char *data, int data_size)
 	int data_len;
 	int opcode;
 	if (state[cnum] == WS_HTTP)
-		return process_http_req(cnum);
+		return process_http_req();
 
 	if ((data_len = read_websocket_frame(data, data_size, &opcode)) < 0)
 		return (-1);

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -1685,7 +1685,7 @@ void ProcessRcvdARQFrame(UCHAR intFrameType, UCHAR * bytData, int DataLen, bool 
 
 				SetARDOPProtocolState(ISS);
 				ARQState = ISSData;
-				SendData(false);
+				SendData();
 				return;
 			}
 			// In an active ARQ Connection, only send an IDFrame when ProtocolState

--- a/src/common/Webgui.h
+++ b/src/common/Webgui.h
@@ -6,6 +6,7 @@
 extern int WebGuiNumConnected;
 
 // TODO: Add documentation for these functions
+int encodeUvint(char *buf, int size, unsigned int uvalue);
 void WebguiInit();
 void WebguiPoll();
 int wg_send_hostdatat(int cnum, char *prefix, unsigned char *data, int datalen);
@@ -35,10 +36,9 @@ int wg_send_rxsilent(int cnum);
 int wg_send_txenabled(int cnum, bool enabled);
 int wg_send_capturechannel(int cnum);
 int wg_send_playbackchannel(int cnum);
+int wg_send_devices(int cnum, char **ss, char **cs);
 int wg_send_audiodevices(int cnum, DeviceInfo **devices, char *cdevice,
 	char *pdevice, bool crestore, bool prestore);
-int wg_send_pttdevice(int cnum, char *devstr);
-int wg_send_catdevice(int cnum, char *devstr);
 int wg_send_ptton(int cnum, char *hexstr);
 int wg_send_pttoff(int cnum, char *hexstr);
 int wg_send_pixels(int cnum, unsigned char *data, size_t datalen);

--- a/src/common/ardopcommon.h
+++ b/src/common/ardopcommon.h
@@ -479,6 +479,8 @@ extern DeviceInfo **AudioDevices;  // A list of all audio devices (Capture and P
 void InitDevices(DeviceInfo ***devicesptr);
 int ExtendDevices(DeviceInfo ***devicesptr);
 void FreeDevices(DeviceInfo ***devicesptr);
+void FreeStrlist(char ***slistptr);
+void LogStrlist(char **slist, char *headstr, bool asnamedesc);
 bool DevicesToCSV(DeviceInfo **devices, char *dst, int dstsize, bool forcapture);
 void LogDevices(DeviceInfo **devices, char *headstr, bool inputonly, bool outputonly);
 int FindAudioDevice(char *devstr, bool iscapture);
@@ -491,3 +493,7 @@ int getCch(bool quiet);
 // should normally be true, unless GetDevices() was just called.
 void updateWebGuiAudioConfig(bool do_getdevices);
 
+// Send updated info about non-audio system configuration to WebGui.  This
+// should be called whenever a change to this configuration is made (or detected
+// due to a failure).
+void updateWebGuiNonAudioConfig();

--- a/src/common/os_util.h
+++ b/src/common/os_util.h
@@ -53,7 +53,8 @@ int nbrecv(int sockfd, char *data, size_t len);
 // mostly to produce better error messages if something fails.
 // Return a file descriptor on success.  If an error occurs, log the error
 // and return -1;
-int tcpconnect(char *address, int port);
+// However, if testing is true, then do not log an error if unable to open.
+int tcpconnect(char *address, int port, bool testing);
 // Return 0 on success.  If an error occurs, log the error
 // and return -1;
 int tcpsend(int fd, unsigned char *data, size_t datalen);
@@ -66,6 +67,9 @@ HANDLE OpenCM108(char *devstr);
 // and return -1;
 int CM108_set_ptt(HANDLE fd, bool State);
 void CloseCM108(HANDLE *fd);
+
+char** GetSerialStrlist();
+char** GetCM108Strlist();
 
 // Items below are platform specific
 #ifdef WIN32

--- a/src/common/ptt.h
+++ b/src/common/ptt.h
@@ -51,3 +51,16 @@ void close_CAT(bool statusmsg);
 // that either the host program must do PTT control or the radio must be
 // configured to use VOX, which is not recommended.
 bool isPTTmodeEnabled();
+
+// Return true PTT control CAT via CAT was usable more recently than via a
+// non-CAT control device.
+bool wasLastGoodControlCAT();
+
+// Encode a list of devices to the format required by wg_send_devices().  Return
+// the number of bytes written to dst.
+// On return, dst is NOT a null terminated string.
+// Include found serial and CM108 devices, as well as RIGCTLD and TCP:4532
+// (without attepting to verify that they are available).  If LastGoodCATstr or
+// LastGoodPTTstr is not an empty string and does not match any value in the
+// encoded device list, then also include them.
+size_t EncodeDeviceStrlist(char *dst, int dstsize, char **ss, char **cs);

--- a/src/windows/os_util.c
+++ b/src/windows/os_util.c
@@ -13,6 +13,9 @@
 
 #include <hidsdi.h>
 #include <cfgmgr32.h>
+#include <initguid.h>
+#include <devguid.h>
+#include <setupapi.h>
 
 #define TARGET_RESOLUTION 1  // 1-millisecond target resolution
 
@@ -23,6 +26,18 @@ extern char DecodeWav[5][256];
 extern int WavNow;  // Time since start of WAV file being decoded
 extern bool blnClosing;
 
+
+void LogError(char *msgstr, DWORD err) {
+	LPVOID errstr;
+	FormatMessageA(
+		FORMAT_MESSAGE_ALLOCATE_BUFFER
+		| FORMAT_MESSAGE_FROM_SYSTEM
+		| FORMAT_MESSAGE_IGNORE_INSERTS,
+		NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+		(LPTSTR) &errstr, 0, NULL);
+	ZF_LOGE("%s (%lu) %s", msgstr, err, (LPCTSTR) errstr);
+	LocalFree(errstr);
+}
 
 BOOL CtrlHandler(DWORD fdwCtrlType) {
 	switch( fdwCtrlType ) {
@@ -84,7 +99,7 @@ int platform_init() {
 	wTimerRes = min(max(tc.wPeriodMin, TARGET_RESOLUTION), tc.wPeriodMax);
 	timeBeginPeriod(wTimerRes);
 	if(SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS) == 0)
-		ZF_LOGW("Failed to set High Priority (%lu)", GetLastError());
+		LogError("ERROR: Failed to set process to High Priority.", GetLastError());
 
 	return (0);
 }
@@ -148,10 +163,13 @@ HANDLE OpenCOMPort(VOID * pPort, int speed) {
 		NULL
 	);
 	if (fd == (HANDLE) -1) {
+		DWORD err = GetLastError();
+		char errmsg[32];
 		if (atoi(pPort) != 0)
-			ZF_LOGE("COM%d could not be opened", atoi(pPort));
+			snprintf(errmsg, sizeof(errmsg), "COM%d could not be opened.", atoi(pPort));
 		else
-			ZF_LOGE("%s could not be opened", (char *) pPort);
+			snprintf(errmsg, sizeof(errmsg), "%s could not be opened.", (char *) pPort);
+		LogError(errmsg, err);
 		return 0;
 	}
 
@@ -191,11 +209,13 @@ HANDLE OpenCOMPort(VOID * pPort, int speed) {
 
 	fRetVal = SetCommState(fd, &dcb);
 	if (!fRetVal) {
+		DWORD err = GetLastError();
+		char errmsg[32];
 		if (atoi(pPort) != 0)
-			ZF_LOGE("COM%d Setup Failed %lu ", atoi(pPort), GetLastError());
+			snprintf(errmsg, sizeof(errmsg), "COM%d setup Failed.", atoi(pPort));
 		else
-			ZF_LOGE("%s Setup Failed %lu ", (char *) pPort, GetLastError());
-
+			snprintf(errmsg, sizeof(errmsg), "%s setup Failed.", (char *) pPort);
+		LogError(errmsg, err);
 		CloseHandle(fd);
 		return 0;
 	}
@@ -285,7 +305,8 @@ int nbrecv(int sockfd, char *data, size_t len) {
 // mostly to produce better error messages if something fails.
 // Return a file descriptor on success.  If an error occurs, log the error
 // and return -1;
-int tcpconnect(char *address, int port) {
+// However, if testing is true, then do not log an error if unable to open.
+int tcpconnect(char *address, int port, bool testing) {
 	static bool wsa_started = false;
 	WSADATA wsaData;
 	struct sockaddr_in addr;
@@ -308,32 +329,23 @@ int tcpconnect(char *address, int port) {
 		return (-1);
 	}
 	if ((fd = socket(AF_INET, SOCK_STREAM, 0)) < 0) {
-		int err = WSAGetLastError();
-		char *errstr = NULL;
-		FormatMessageA(
-			FORMAT_MESSAGE_ALLOCATE_BUFFER
-			| FORMAT_MESSAGE_FROM_SYSTEM
-			| FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-			(LPSTR)&errstr, 0, NULL);
-		ZF_LOGE("Error creating socket for TCP port for %s:%i. %s",
-			address, port, errstr);
-		LocalFree(errstr);
+		DWORD err = WSAGetLastError();
+		char errmsg[64];
+		snprintf(errmsg, sizeof(errmsg),
+			"Error creating socket for TCP port for %s:%i.",
+			address, port);
+		LogError(errmsg, err);
 		return (-1);
 	}
 	if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) < 0) {
-		int err = WSAGetLastError();
-		char *errstr = NULL;
-		FormatMessageA(
-			FORMAT_MESSAGE_ALLOCATE_BUFFER
-			| FORMAT_MESSAGE_FROM_SYSTEM
-			| FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-			(LPSTR)&errstr, 0, NULL);
-		ZF_LOGE("Error connecting to TCP port at %s:%i. %s",
-			address, port, errstr);
-		LocalFree(errstr);
-		closesocket(fd);
+		DWORD err = WSAGetLastError();
+		char errmsg[64];
+		if (!testing) {
+			snprintf(errmsg, sizeof(errmsg),
+				"Error connecting to TCP port at %s:%i.",
+				address, port);
+			LogError(errmsg, err);
+		}
 		return (-1);
 	}
 	// set socket to be non-blocking
@@ -346,16 +358,7 @@ int tcpconnect(char *address, int port) {
 // and return -1;
 int tcpsend(int fd, unsigned char *data, size_t datalen) {
 	if (send(fd, (char *) data, datalen, 0) != (int) datalen) {
-		int err = WSAGetLastError();
-		char *errstr = NULL;
-		FormatMessageA(
-			FORMAT_MESSAGE_ALLOCATE_BUFFER
-			| FORMAT_MESSAGE_FROM_SYSTEM
-			| FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-			(LPSTR)&errstr, 0, NULL);
-		ZF_LOGE("Error sending data to TCP port. %s", errstr);
-		LocalFree(errstr);
+		LogError("Error sending data to TCP port.", WSAGetLastError());
 		return (-1);
 	}
 	return 0;
@@ -394,14 +397,28 @@ bool verify_compat(HANDLE handle) {
 	return true;
 }
 
+// Unless vid < 0, name and desc should be NULL and descz should be 0.
 // if vid=0, return the handle if the device can be opened and
 //    verify_compat() is true.  otherwise close it and return 0;
-// If vid=-1, log info if vid:pid match a known CM-108 compatible device
-// If vid=-2, log info if able to open and get VID:PID
-// For both of these cases, always close the handle and return 0.
+// If vid=-1, log/return name, desc if vid:pid match a known CM-108
+//  compatible device
+// If vid=-2, log/return name, desc if able to open and get VID:PID
+// For both of these cases:
+//  Always close the handle and return 0.
+//  If name or desc is NULL or namesz or descsz is 0, then log the VID:PID and
+//   additional details.
+//  If name and desc are not NULL and namesz and descsz are greater than 0,
+//   write VID:PID to name and description to desc.
+//  If valid VID:PID not found, set name and desc to empty strings ("").
 // For any other vid, pid, return the handle if VID:PID matches vid:pid and
 //   verify_compat() is true, else close the handle and return 0;
-HANDLE open_hid_by_devid(char *deviceid, int vid, int pid) {
+HANDLE open_hid_by_devid(char *deviceid, int vid, int pid, char *name,
+	size_t namesz, char *desc, size_t descsz
+) {
+	if (name != NULL && desc != NULL && namesz > 0 && descsz > 0) {
+		name[0] = 0x00;  // empty string;
+		desc[0] = 0x00;  // empty string;
+	}
 	HANDLE handle = CreateFile(deviceid,
 		GENERIC_READ | GENERIC_WRITE,
 		FILE_SHARE_READ | FILE_SHARE_WRITE,
@@ -436,8 +453,8 @@ HANDLE open_hid_by_devid(char *deviceid, int vid, int pid) {
 		return 0;
 	}
 	if (vid == -1) {
-		// Return 0 without writing to the log if VID:PID don't match a known
-		// CM108 compatible HID devices
+		// Return 0 without setting name or desc or writing to the log if
+		// VID:PID don't match a known CM108 compatible HID devices
 		if (Attributes.VendorID == CM108VID) {
 			int i;
 			for (i = 0; i <= CM108PIDSLEN; ++i) {
@@ -459,18 +476,189 @@ HANDLE open_hid_by_devid(char *deviceid, int vid, int pid) {
 	}
 
 	// Write info to log
-	wchar_t Product[128];
+	wchar_t Product[256];
 	char ProductStr[256];
 	ProductStr[0] = 0x00;  // empty str
 	if (HidD_GetProductString(handle, Product, 128))
 		wcstombs(ProductStr, Product, sizeof(ProductStr));
 	// Manufacturer, Serial Number, etc. also available, but dont seem to
 	// be useful in most cases
-	ZF_LOGI("VID:PID=\"%04X:%04X\" %s %s",
-		Attributes.VendorID, Attributes.ProductID, ProductStr, deviceid);
+	if (name != NULL && desc != NULL && namesz > 0 && descsz > 0) {
+		snprintf(name, namesz, "%04X:%04X",
+			Attributes.VendorID, Attributes.ProductID);
+		snprintf(desc, descsz, "%s", ProductStr);
+	} else {
+		ZF_LOGI("VID:PID=\"%04X:%04X\" %s %s",
+			Attributes.VendorID, Attributes.ProductID, ProductStr, deviceid);
+	}
 	CloseHandle(handle);
 	devices_logged += 1;
 	return 0;
+}
+
+// Return an alternating list of the names and descriptions of available serial
+// devices, or NULL if an error occurs or none are found.  The name is suitable
+// for passing to parse_catstr() or parse_pttstr() where an optional RTS: or
+// DTR: prefix may be applied.  These will all have the form "COMn".  The
+// description is optional, and shall be an empty string ("") if no description
+// is available.  Use SPDRP_FRIENDLYNAME for description.
+// So, returned list shall have an even number of non-NULL strings, followed
+// by one or more NULL pointers.
+// Unless the return value is NULL, use FreeStrlist() to free it when done.
+char** GetSerialStrlist() {
+	char **slist = NULL;
+	int slistsize = 0;
+	HDEVINFO hDevInfo;
+	char DevName[8];
+	DWORD DevNameSz = sizeof(DevName);  // available space for name
+	char DevDesc[256];
+	HKEY regKey;
+	DWORD err;
+	SP_DEVINFO_DATA DeviceInfoData;
+	DeviceInfoData.cbSize = sizeof(DeviceInfoData);
+
+	hDevInfo = SetupDiGetClassDevs(&GUID_DEVCLASS_PORTS, NULL, NULL,
+		DIGCF_PRESENT);
+	if (hDevInfo == INVALID_HANDLE_VALUE) {
+		LogError("Error in SetupDiGetClassDevs()", GetLastError());
+		return slist;
+	}
+
+	for (int i = 0;
+		SetupDiEnumDeviceInfo(hDevInfo, i, &DeviceInfoData); ++i
+	) {
+		if ((regKey = SetupDiOpenDevRegKey(hDevInfo, &DeviceInfoData,
+			DICS_FLAG_GLOBAL, 0, DIREG_DEV, KEY_READ)) == INVALID_HANDLE_VALUE
+		) {
+			LogError("Error in SetupDiOpenDevRegKey()", GetLastError());
+			continue;
+		}
+		if ((err = RegQueryValueEx(regKey, "portname", NULL, NULL, (BYTE*) DevName,
+			&DevNameSz)) != ERROR_SUCCESS
+		) {
+			LogError("Error in RegQueryValueEx()", err);
+			RegCloseKey(regKey);
+			continue;
+		}
+		RegCloseKey(regKey);
+		if (slist == NULL) {
+			if ((slist = (char **) malloc(sizeof(char *))) == NULL) {
+				ZF_LOGE("Error from malloc() in GetSerialStrlist() (%s)",
+					strerror(errno));
+				return slist;
+			}
+			slistsize = 1;
+			slist[slistsize - 1] = NULL;  // Last pointer must always be null
+		}
+		slistsize += 2;
+		if ((slist = (char **) realloc(slist, slistsize * sizeof(char *)))
+			== NULL
+		) {
+			ZF_LOGE("Error from realloc() in GetSerialStrlist() (%s)",
+				strerror(errno));
+			return slist;
+		}
+		slist[slistsize - 3] = strdup(DevName);
+		if (SetupDiGetDeviceRegistryProperty(hDevInfo, &DeviceInfoData,
+			SPDRP_FRIENDLYNAME, NULL, (BYTE*) DevDesc, sizeof(DevDesc), NULL)
+		)
+			slist[slistsize - 2] = strdup(DevDesc);
+		else
+			slist[slistsize - 2] = strdup("");  // empty string
+		slist[slistsize - 1] = NULL;  // Last pointer must always be null
+	}
+	if ((err = GetLastError()) != ERROR_NO_MORE_ITEMS)
+		LogError("Error in SetupDiEnumDeviceInfo()", err);
+	return slist;
+}
+
+
+
+// Return an alternating list of the names and descriptions of available CM108
+// compatible devices, or NULL if an error occurs or none are found.  The name
+// is suitable for passing to parse_pttstr().  These will all have the form
+// CM108:VID:PID where VID and PID are each 4-digit hex strings.  The
+// description is optional, and shall be an empty string ("") if no description
+// is available.  Use SPDRP_FRIENDLYNAME for description.
+// So, returned list shall have an even number of non-NULL strings, followed
+// by one or more NULL pointers.
+// Unless the return value is NULL, use FreeStrlist() to free it when done.
+char** GetCM108Strlist() {
+	char **slist = NULL;
+	int slistsize = -1;
+	char namewithprefix[16] = "CM108:VIDX:PIDX";
+	char *name = namewithprefix + strlen("CM108:");  // Write VID:PID to here
+	int namesz = sizeof(namewithprefix) - strlen("CM108:");
+	char desc[200];
+
+	GUID HidGuid;
+	HidD_GetHidGuid(&HidGuid);
+	CONFIGRET cr = CR_BUFFER_SMALL;
+	char *DeviceInterfaceList = NULL;
+	unsigned long DeviceInterfaceListLength = 0;
+	HANDLE handle;
+	while (cr == CR_BUFFER_SMALL) {
+		// Adapted from example at
+		// https://learn.microsoft.com/en-us/windows/win32/api/cfgmgr32/
+		// nf-cfgmgr32-cm_get_device_interface_lista
+		cr = CM_Get_Device_Interface_List_Size(&DeviceInterfaceListLength,
+			(LPGUID)&HidGuid, NULL, CM_GET_DEVICE_INTERFACE_LIST_ALL_DEVICES);
+		if (cr != CR_SUCCESS)
+			break;
+		if (DeviceInterfaceList != NULL)
+			HeapFree(GetProcessHeap(), 0, DeviceInterfaceList);
+		DeviceInterfaceList = (PSTR)HeapAlloc(GetProcessHeap(),
+			HEAP_ZERO_MEMORY, DeviceInterfaceListLength * sizeof(WCHAR));
+		if (DeviceInterfaceList == NULL) {
+			cr = CR_OUT_OF_MEMORY;
+			break;
+		}
+		cr = CM_Get_Device_Interface_List((LPGUID)&HidGuid,
+			NULL, DeviceInterfaceList, DeviceInterfaceListLength,
+			CM_GET_DEVICE_INTERFACE_LIST_ALL_DEVICES);
+	}
+	if (cr != CR_SUCCESS) {
+		ZF_LOGE("Error in CM_Get_Device_Interface_List_SizeW()");
+		return 0;
+	}
+
+	while (strlen(DeviceInterfaceList) != 0) {
+		// Using vid=-1.  If this were changed to -2, it would return all
+		// VID:PID, not just those that are recognized as CM108 compatible
+		// devices
+		handle = open_hid_by_devid(DeviceInterfaceList, -1, 0, name, namesz,
+			desc, sizeof(desc));
+		if (handle != 0) {
+			// This shouldn't happen
+			ZF_LOGE("Error from open_hid_by_devid();");
+			return slist;
+		}
+		if (name[0] != 0x00) {
+			// CM108 compatible device found.
+			if (slist == NULL) {
+				if ((slist = (char **) malloc(sizeof(char *))) == NULL) {
+					ZF_LOGE("Error from malloc() in GetCM108Strlist() (%s)",
+						strerror(errno));
+					return slist;
+				}
+				slistsize = 1;
+				slist[slistsize - 1] = NULL;  // Last pointer must always be null
+			}
+			slistsize += 2;
+			if ((slist = (char **) realloc(slist, slistsize * sizeof(char *)))
+				== NULL
+			) {
+				ZF_LOGE("Error from realloc() in GetCM108Strlist() (%s)",
+					strerror(errno));
+				return slist;
+			}
+			slist[slistsize - 3] = strdup(namewithprefix);
+			slist[slistsize - 2] = strdup(desc);
+			slist[slistsize - 1] = NULL;  // Last pointer must always be null
+		}
+		DeviceInterfaceList += strlen(DeviceInterfaceList) + 1;
+	}
+	return slist;
 }
 
 
@@ -491,7 +679,7 @@ HANDLE OpenCM108(char *devstr) {
 	// device, and return the HANDLE.
 	if (strncmp(devstr, "\\\\?\\HID", strlen("\\\\?\\HID")) == 0)
 		// Use vid=0 to return handle if valid, else return 0
-		return open_hid_by_devid(devstr, 0, 0);
+		return open_hid_by_devid(devstr, 0, 0, NULL, 0, NULL, 0);
 
 	devices_logged = 0;
 	int vid;
@@ -560,7 +748,7 @@ HANDLE OpenCM108(char *devstr) {
 	}
 
 	while (strlen(DeviceInterfaceList) != 0) {
-		handle = open_hid_by_devid(DeviceInterfaceList, vid, pid);
+		handle = open_hid_by_devid(DeviceInterfaceList, vid, pid, NULL, 0, NULL, 0);
 		if (handle != 0)
 			return handle;
 		DeviceInterfaceList += strlen(DeviceInterfaceList) + 1;
@@ -595,17 +783,7 @@ int CM108_set_ptt(HANDLE fd, bool State) {
 
 	DWORD NumberOfBytesWritten;
 	if (!WriteFile(fd, io, 5, &NumberOfBytesWritten, NULL)) {
-		ZF_LOGE("ERROR: Failure of PTT via CM108.");
-		LPVOID errstr;
-		DWORD err = GetLastError();
-		FormatMessageA(
-			FORMAT_MESSAGE_ALLOCATE_BUFFER
-			| FORMAT_MESSAGE_FROM_SYSTEM
-			| FORMAT_MESSAGE_IGNORE_INSERTS,
-			NULL, err, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
-			(LPTSTR) &errstr, 0, NULL);
-		ZF_LOGE("GetLastError() -> (%lu) %s", err, (LPCTSTR) errstr);
-		LocalFree(errstr);
+		LogError("ERROR: Failure of PTT via CM108.", GetLastError());
 		return (-1);
 	}
 	if (NumberOfBytesWritten != 5) {

--- a/test/ardop/test_ARDOPCommon_processargs.c
+++ b/test/ardop/test_ARDOPCommon_processargs.c
@@ -189,15 +189,28 @@ HANDLE __wrap_OpenCOMPort(void * Port, int speed) {
 	return (HANDLE) ((size_t) mock());
 }
 
-int __wrap_tcpconnect(char *address, int port) {
+int __wrap_tcpconnect(char *address, int port, bool testing) {
 	(void) address;  // This line avoids an unused parameter warning
 	(void) port;  // This line avoids an unused parameter warning
+	(void) testing;  // This line avoids an unused parameter warning
 	return (int) ((size_t) mock());
 }
 
 int __wrap_OpenCM108(char * devstr) {
 	(void) devstr;  // This line avoids an unused parameter warning
 	return (int) ((size_t) mock());
+}
+
+void __wrap_updateWebGuiNonAudioConfig() {
+	return;
+}
+
+char** __wrap_GetCM108Strlist() {
+	return NULL;
+}
+
+char** __wrap_GetSerialStrlist() {
+	return NULL;
 }
 
 // For diagnostic purposes, print the results capture by some of the __wrap
@@ -218,6 +231,7 @@ void reset_defaults() {
 	PTTstr[0] = 0x00;
 
 	hCATdevice = 0;
+	tcpCATport = 0;
 	hPTTdevice = 0;
 	hCM108device = 0;
 	GPIOpin = 0;
@@ -1071,9 +1085,9 @@ static void test_processargs(void** state) {
 		ret = processargs(testargc, testargv);
 		//print_printstrs();
 		//__real_printf("%i: %s\n", printindex, printstrs[printindex]);
-		// nstartstrings=3 + cmdstr + 2*TCPCAT ERR + 2*info about no audio/ptt
-		//  devices specified.
-		assert_int_equal(printindex, 7);
+		// nstartstrings=3 + cmdstr + 2*CATPTT + 2*TCPCAT ERR + 2*info about
+		//  no audio/ptt devices specified.
+		assert_int_equal(printindex, 9);
 		assert_string_equal(PTTstr, "");
 		assert_string_equal(CATstr, "");
 		assert_int_equal(hPTTdevice, 0);
@@ -1081,8 +1095,8 @@ static void test_processargs(void** state) {
 		assert_int_equal(hCATdevice, 0);
 		assert_int_equal(tcpCATport, 0);
 		assert_int_equal(PTTmode, 0x00);
-		assert_int_equal(ptt_on_cmd_len, 0);
-		assert_int_equal(ptt_off_cmd_len, 0);
+		assert_int_equal(ptt_on_cmd_len, 4);
+		assert_int_equal(ptt_off_cmd_len, 4);
 	}
 	reset_defaults();  // reset global variables changed by processargs
 	reset_printstrs();  // reset captured strings from last test
@@ -1120,9 +1134,9 @@ static void test_processargs(void** state) {
 		ret = processargs(testargc, testargv);
 		//print_printstrs();
 		//__real_printf("%i: %s\n", printindex, printstrs[printindex]);
-		// nstartstrings=3 + cmdstr + 2*TCPCAT ERR + 2*info about no audio/ptt
-		//  devices specified.
-		assert_int_equal(printindex, 7);
+		// nstartstrings=3 + cmdstr + 2*CATPTT + 2*TCPCAT ERR + 2*info about
+		//  no audio/ptt devices specified.
+		assert_int_equal(printindex, 9);
 		assert_string_equal(PTTstr, "");
 		assert_string_equal(CATstr, "");
 		assert_int_equal(hPTTdevice, 0);
@@ -1130,8 +1144,8 @@ static void test_processargs(void** state) {
 		assert_int_equal(hCATdevice, 0);
 		assert_int_equal(tcpCATport, 0);
 		assert_int_equal(PTTmode, 0x00);
-		assert_int_equal(ptt_on_cmd_len, 0);
-		assert_int_equal(ptt_off_cmd_len, 0);
+		assert_int_equal(ptt_on_cmd_len, 4);
+		assert_int_equal(ptt_off_cmd_len, 4);
 	}
 	reset_defaults();  // reset global variables changed by processargs
 	reset_printstrs();  // reset captured strings from last test

--- a/webgui/webgui.html
+++ b/webgui/webgui.html
@@ -114,7 +114,8 @@
 			only briefly).  So, making changes while transmitting or receiving
 			is not recommended.</b><br /><br />
 
-			<button id="codectoggle">ENABLE Audio Processing</button><br /><br />
+			<button id="codectoggle">ENABLE Audio Processing</button>
+			<button id="ptttoggle">ENABLE PTT/CAT Control</button><br /><br />
 
 			RX Audio Device:
 			<select name="rxselect" id="rxselect"></select><br />
@@ -122,14 +123,26 @@
 			<select name="txselect" id="txselect"></select><br />
 			<button id="getdevices">Refresh audio devices list</button><br />
 			<br />
-			For these settings, type a new value and press enter to change.
-			Device names should be the same as would be entered on the
-			command line or the special values of NONE or RESTORE<br />
+			The next two selectors include available and commonly used devices
+			that may be suitable for CAT/PTT.  Some listed devices may not
+			actually be usable.<br />
+			PTT Selector:
+			<select name="pttselect" id="pttselect"></select><br />
+			CAT Selector:
+			<select name="catselect" id="catselect"></select><br />
+			<button id="getnadevices">Refresh CAT/PTT devices list</button><br />
+			<small>Because some less commonly used devices may not be included
+			in the selectors above, you may also type a device name into the
+			text inputs below.  These accept any value that can be used with the
+			--cat and --ptt command line options, as well as the special values
+			of NONE and RESTORE.  It may also be necessary to use these inputs
+			if non-default baud rates are required for serial devices.</small>
+			<br />
 			PTT device: <input type="text" id="pttdev"></input><br />
 			CAT device: <input type="text" id="catdev"></input><br />
 			CAT PTTON string (hex): <input type="text" id="ptton"></input><br />
-			CAT PTTONFFstring (hex): <input type="text" id="pttoff"></input><br /><br />
-
+			CAT PTTONFFstring (hex): <input type="text" id="pttoff"></input>
+			<br /><br />
 			MONO is usually used, except when using a dual VFO system that has
 			audio from VFO A on one channel and VFO B on the other.
 			<br />
@@ -378,12 +391,14 @@
 			to configure or reconfigure the audio and CAT/PTT devices used by ardopcf.
 			As indicated by the warning at the top of this section <b>Changing these settings
 			may disrupt audio processing (maybe only briefly). So, making changes while
-			transmitting or receiving is not recommended.</b>  Of these controls, the item
-			most likely to be useful is the <b>DISABLE/ENABLE Audio Processing</b> button.
-			This button can be used to temporily disable, and later re-enable audio processing.
+			transmitting or receiving is not recommended.</b>  Of these controls, the items
+			most likely to be useful are the <b>DISABLE/ENABLE Audio Processing</b> and
+			<b>DISABLE/ENABLE PTT/CAT Control</b> buttons. These buttons can be used to
+			temporarily disable, and later re-enable audio processing and PTT/CAT control.
 			Disabling audio processing reduces CPU/power usage by the computer that ardopcf is
-			running on, and should also be done before disconnecting or turning off the audio
-			devices used.
+			running on.  Both of these should also be disabled before disconnecting or turning
+			off the audio and control devices used.  In most cases, disconnecting without first
+			disabling them will also work, but in certain cases this may cause problems.
 			</p><p>
 			The <b>ENABLE Audio Processing</b> button doesn't work unless the audio devices
 			were previously successfully configured, and then <b>DISABLED</b>.  To initially
@@ -398,14 +413,88 @@
 			also included in the list of devices.  Selecting <b>RESTORE</b> causes ardopcf
 			to attempt to re-open the last device that was successfully opened and configured.
 			</p><p>
-			The remaining configuration controls duplicate the functionality of
-			some commandline options.  See the documentation for those options for more
-			details.  By providing these controls within the WebGUI, ardopcf can be started
+			The <b>ENABLE PTT/CAT Control</b> button doesn't work unless a PTT control device
+			or CAT control device plus the CAT PTTON and CAT PTTOFF settings were previously
+			successfully configured, and then <b>DISABLED</b>.  To initially configure the
+			PTT or CAT devices, or select devices different from what were previously
+			configured, select appropriate devices from the <b>PTT Selector</b> and/or
+			<b>CAT Selector</b> controls.  These include detected serial and CM108 devices as
+			well as available connections to the default TCP:4532 port used by Hamlib/rigctld.
+			</p><p>
+			If the <b>RX Audio Device</b>, <b>TX Audio Device</b>, <b>PTT Selector</b>, or
+			<b>CAT Selector</b> still shows <b>NONE</b> after you use one of the <b>ENABLE</b>
+			buttons or choose another value from one of these selectors, this indicates that
+			an attempt to open and configure the device failed.  You might find additional
+			details in the debug log file to help you understand why it failed.
+			</p><p>
+			It is likely that only one or two of the CAT/PTT items is actually usable.  Unlike
+			the audio device selectors that, with a bit of trial an error, can probably be
+			used to configure a working system without knowing too much about the details of
+			your hardware, the PTT/CAT device selectors are probably not as intuitive.  The
+			selectors are better than having to type in device names because they are quicker
+			and avoid typos.  However, to use them effectively, you still need to understand
+			the capabilities of the hardware that you are using.  For example, many serial
+			devices can use either RTS or DTR for PTT control.  Both are listed, but only one
+			will work.  On Linux, all hidraw human interface devices will be listed as
+			possible CM108 PTT control devices, including completely unrelated devices.
+			Similarly, on Windows, any CM108 compatible audio device will be listed as a
+			CM108 PTT control device even if, like the Digirig Mobile, pin 3 of that board is
+			not wired to control the radio's PTT.
+			<b>NONE</b> can be used to close the current PTT or CAT device if one is open.
+			If a device has previously been successfully configured, then a special
+			<b>RESTORE</b> item is also included in the list of devices.  Selecting
+			<b>RESTORE</b> causes ardopcf to attempt to re-open the last device that was
+			successfully opened.
+			</p><p>
+			The <b>PTT Selector</b> and <b>CAT Selector</b> controls do not include every
+			possible value that you might need to use.  So, the <b>PTT device</b> and
+			<b>CAT device</b> text inputs are also provided.  These accept any value that can
+			be used with the --cat and --ptt command line options, as well as the special
+			values of NONE and RESTORE.  For example, on Raspberry Pi computers, it is
+			possible to connect custom hardware to one of the GPIO electrical connectors and
+			use that for PTT control.  This option is not listed in the <b>PTT Selector</b>
+			by default, but it may be entered into the <b>PTT device</b> text input as
+			'GPIO:N', where N is the GPIO pin number.  It may also be necessary to use these
+			inputs if non-default baud rates are required for serial devices.  See the
+			documentation for the --ptt and --cat command line options for more details.
+			</p><p>
+			Even for devices such as GPIO pins or serial devices that require manual
+			configuration because they do not appear in the selector lists, once
+			successfully configured either from the text input fields in the Webgui or from
+			the command line, the <b>ENABLE/DISABLE CAT/PTT</b> button and/or the <b>NONE</b>
+			and <b>RESTORE</b> values in the selectors can be used to temporarily disable them,
+			and then later re-enable them.
+			<p></p>
+			I see a few use cases for this ability to disable and later re-enable PTT control.
+			The first is that, especially during portable operations, it may be convenient to
+			disconnect and later reconnect the cable between the radio and computer.  You
+			should disable the PTT/CAT device (as well as the audio devices) before
+			disconnecting.  In most cases, disconnecting without first disabling them will
+			also work, but in certain cases this may cause problems.  Then, after reconnecting,
+			you can re-enable the devices.  A second use case for temporarily disabling
+			PTT/CAT is to temporarily prevent unplanned transmitting, such as might occur to
+			meet ID requirements, when doing so might cause equipment damage or injury because
+			you need to make adjustments to your antenna or feedline.
+			</p><p>
+			To use CAT for PTT control, unless you are used the RIGCTRL shortcut to set up
+			TCP CAT via Hamlib/rigctld, you must also provide <b>PTTON</b> and <b>PTTOFF</b>
+			commands expressed as hex strings.  The required values are specific to the make
+			and model of radio being used.  So, you must search the internet or the manual
+			for your radio to discover what is required.  Text inputs are provided for these.
+			</p><p>
+			The <b>RX Audio Channel</b> and <b>TX Audio Channel</b> selectors control whether
+			the audio devices are opened as mono or stereo devices, and when opened as stereo
+			devices, whether the left or right channel is used.  In most cases, the <b>MONO</b>
+			setting is appropriate.  The <b>LEFT</b> or <b>RIGHT</b> setting for
+			<b>RX Audio Channel</b> may be necessary when using a dual VFO radio that provides
+			audio from one VFO on the left channel and audio from the other VFO on the right
+			channel.  I am not currently aware of a use case for other than <b>MONO</b> on the
+			<b>TX Audio Channel</b> selector.
+			</p><p>
+			By providing these controls within the WebGUI, ardopcf can be started
 			without specifying these options, and it may be reconfigured to change which
 			devices are used and how they are configured without having to exit and restart
-			ardopcf.  Unlike the command line options, special values of <b>NONE</b> and
-			<b>RESTORE</b> may also be used in the <b>PTT device</b> and <b>CAT device</b>
-			input fields.
+			ardopcf.
 			</p><p>
 			The various items displayed in this WebGUI can change quickly during an Ardop ARQ
 			connection.  The debug log file created by ardopcf contains most of this same


### PR DESCRIPTION
This PR extends the new features added by PR #152 and further supports Issues #139, #137, and #123 by generating lists of possible CAT/PTT devices that can be presented to the user in the WebGui.  Due to the greater complexity of CAT/PTT devices and their configuration options compared to audio devices, not all device options are listed.  Therefore, text inputs are also still provided for these devices in the WebGui.

As with the `ENABLE/DISABLE Audio Processing` button added in PR #152, the new `ENABLE/DISABLE PTT/CAT Control` button is probably the most useful (and easiest to use) of the new features.  

See the updated help screen in the WebGui for a discussion of why the new PTT/CAT control selectors still require the user to understand the hardware devices that they are using.  This is in contrast the the recently added audio device selectors that are much more intuitive. 