### PR TITLE
Add platform build folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Build directory (contains all build artifacts)
 /build/
 
-# Executables (legacy entries, now covered by /build/)
-CalcTemplates
-
 # Python tests may write a variety of temporary files to /test/python/tmp/
 /test/python/tmp/*
 
@@ -19,15 +16,6 @@ newArdopSampleArrays.c
 
 # WAVs
 *.wav
-# Precompiled Headers
-*.gch
-*.pch
-
-# Libraries
-*.lib
-*.a
-*.la
-*.lo
 
 # Shared objects (inc. Windows DLLs)
 *.dll
@@ -42,12 +30,6 @@ newArdopSampleArrays.c
 *.i*86
 *.x86_64
 *.hex
-
-# Debug files
-*.dSYM/
-*.su
-*.idb
-*.pdb
 
 # Editor garbage
 /.vscode/**

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,8 @@
-# Executables
-ardopcf
+# Build directory (contains all build artifacts)
+/build/
+
+# Executables (legacy entries, now covered by /build/)
 CalcTemplates
-/lib/txt2c/txt2c
-/test/ardop/*
-!/test/ardop/*.[ch]
-!/test/ardop/*.bin
 
 # Python tests may write a variety of temporary files to /test/python/tmp/
 /test/python/tmp/*
@@ -21,21 +19,6 @@ newArdopSampleArrays.c
 
 # WAVs
 *.wav
-
-# Prerequisites
-*.d
-
-# Object files
-*.o
-*.ko
-*.obj
-*.elf
-
-# Linker output
-*.ilk
-*.map
-*.exp
-
 # Precompiled Headers
 *.gch
 *.pch

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@
 #		sudo apt install mingw-w64
 #		make CC_NATIVE=gcc CC=i686-w64-mingw32-gcc-posix WIN32=1
 
-.PHONY: all buildtest test
+.PHONY: all buildtest test clean cleanall
 
 # list all object files and their directories
 # keep sorted by filename
@@ -176,6 +176,9 @@ $(BUILDDIR)/src/common/gen-%.c:: webgui/% | $(TXT2C)
 	@$(call MKDIR,$(dir $@))
 	$(TXT2C) $< $@ $(subst .,_,$(notdir $<))
 
+# Keep generated C files (don't delete them as intermediate files)
+.PRECIOUS: $(BUILDDIR)/src/common/gen-%.c
+
 # `make buildtest` builds the test-case executables but does not run them
 buildtest: $(TESTS)
 
@@ -233,8 +236,12 @@ $(BUILDDIR)/%.o: %.c
 ifeq ($(OS),Windows_NT)
 # on Windows, use rmdir for directories
 clean :
+	@if exist "$(subst /,\,$(BUILDDIR))" rmdir /S /Q "$(subst /,\,$(BUILDDIR))"
+cleanall :
 	@if exist build rmdir /S /Q build
 else
 clean :
+	rm -rf $(BUILDDIR)
+cleanall :
 	rm -rf build
 endif

--- a/Makefile
+++ b/Makefile
@@ -44,64 +44,64 @@
 # list all object files and their directories
 # keep sorted by filename
 OBJS = \
-	lib/rockliff/rrs.o \
-	lib/ws_server/ws_server.o \
-	src/common/ARDOPC.o \
-	src/common/ARDOPCommon.o \
-	src/common/ardopSampleArrays.o \
-	src/common/ARQ.o \
-	src/common/BusyDetect.o \
-	src/common/FEC.o \
-	src/common/FFT.o \
-	src/common/HostInterface.o \
-	src/common/Locator.o \
-	src/common/log_file.o \
-	src/common/log.o \
-	src/common/Modulate.o \
-	src/common/Packed6.o \
-	src/common/RXO.o \
-	src/common/sdft.o \
-	src/common/SoundInput.o \
-	src/common/StationId.o \
-	src/common/TCPHostInterface.o \
-	src/common/txframe.o \
-	src/common/wav.o \
-	src/common/gen-webgui.html.o \
-	src/common/gen-webgui.js.o \
-	src/common/Webgui.o \
-	src/common/noise.o \
-	src/common/ptt.o \
-	src/common/eutf8.o \
+	$(BUILDDIR)/lib/rockliff/rrs.o \
+	$(BUILDDIR)/lib/ws_server/ws_server.o \
+	$(BUILDDIR)/src/common/ARDOPC.o \
+	$(BUILDDIR)/src/common/ARDOPCommon.o \
+	$(BUILDDIR)/src/common/ardopSampleArrays.o \
+	$(BUILDDIR)/src/common/ARQ.o \
+	$(BUILDDIR)/src/common/BusyDetect.o \
+	$(BUILDDIR)/src/common/FEC.o \
+	$(BUILDDIR)/src/common/FFT.o \
+	$(BUILDDIR)/src/common/HostInterface.o \
+	$(BUILDDIR)/src/common/Locator.o \
+	$(BUILDDIR)/src/common/log_file.o \
+	$(BUILDDIR)/src/common/log.o \
+	$(BUILDDIR)/src/common/Modulate.o \
+	$(BUILDDIR)/src/common/Packed6.o \
+	$(BUILDDIR)/src/common/RXO.o \
+	$(BUILDDIR)/src/common/sdft.o \
+	$(BUILDDIR)/src/common/SoundInput.o \
+	$(BUILDDIR)/src/common/StationId.o \
+	$(BUILDDIR)/src/common/TCPHostInterface.o \
+	$(BUILDDIR)/src/common/txframe.o \
+	$(BUILDDIR)/src/common/wav.o \
+	$(BUILDDIR)/src/common/gen-webgui.html.o \
+	$(BUILDDIR)/src/common/gen-webgui.js.o \
+	$(BUILDDIR)/src/common/Webgui.o \
+	$(BUILDDIR)/src/common/noise.o \
+	$(BUILDDIR)/src/common/ptt.o \
+	$(BUILDDIR)/src/common/eutf8.o \
 
 # Linux-only object files
 OBJS_LIN = \
-	src/linux/ALSA.o \
-	src/linux/os_util.o \
+	$(BUILDDIR)/src/linux/ALSA.o \
+	$(BUILDDIR)/src/linux/os_util.o \
 
 # Windows-only object files
 OBJS_WIN = \
-	src/windows/Waveform.o \
-	src/windows/os_util.o \
+	$(BUILDDIR)/src/windows/Waveform.o \
+	$(BUILDDIR)/src/windows/os_util.o \
 
 # user-facing executables, like ardopcf
 OBJS_EXE = \
-	src/common/ardopcf.o \
+	$(BUILDDIR)/src/common/ardopcf.o \
 
 # unit test executables
 TESTS = \
-	test/ardop/test_ARDOPCommon \
-	test/ardop/test_HostInterface \
-	test/ardop/test_Locator \
-	test/ardop/test_log \
-	test/ardop/test_Packed6 \
-	test/ardop/test_StationId \
-	test/ardop/test_ARDOPCommon_processargs \
-	test/ardop/test_eutf8 \
-	test/ardop/test_txframe \
+	$(BUILDDIR)/test/ardop/test_ARDOPCommon \
+	$(BUILDDIR)/test/ardop/test_HostInterface \
+	$(BUILDDIR)/test/ardop/test_Locator \
+	$(BUILDDIR)/test/ardop/test_log \
+	$(BUILDDIR)/test/ardop/test_Packed6 \
+	$(BUILDDIR)/test/ardop/test_StationId \
+	$(BUILDDIR)/test/ardop/test_ARDOPCommon_processargs \
+	$(BUILDDIR)/test/ardop/test_eutf8 \
+	$(BUILDDIR)/test/ardop/test_txframe \
 
 # unit test common code
 TEST_OBJS_COMMON = \
-	test/ardop/setup.o \
+	$(BUILDDIR)/test/ardop/setup.o \
 
 # define newline for use with foreach to run tests
 define newline
@@ -127,25 +127,41 @@ TXT2C ?=
 # Leave empty for OS auto-detection
 WIN32 ?= $(filter $(OS),Windows_NT)
 
+# Determine build directory based on target platform
 ifneq ($(WIN32),)
+PLATFORM := windows
 OBJS += $(OBJS_WIN)
 LDLIBS += -lwsock32 -lwinmm -lsetupapi -lws2_32 -lhid
 else
+PLATFORM := linux
 OBJS += $(OBJS_LIN)
 LDLIBS += -lrt -lasound
 endif
 
+# Build directory structure
+BUILDDIR := build/$(PLATFORM)
+
+# Platform-specific directory creation
+ifeq ($(OS),Windows_NT)
+MKDIR = if not exist "$(subst /,\,$1)" mkdir "$(subst /,\,$1)"
+else
+MKDIR = mkdir -p $1
+endif
+
 all: ardopcf
 
-ardopcf: $(OBJS_EXE) $(OBJS)
+ardopcf: $(BUILDDIR)/ardopcf
+
+$(BUILDDIR)/ardopcf: $(OBJS_EXE) $(OBJS)
 	$(CC) $(LDFLAGS) $^ -o $@ $(LOADLIBES) $(LDLIBS)
 
 # if txt2c is not provided, build it
 ifeq ($(TXT2C),)
-TXT2C := lib/txt2c/txt2c
+TXT2C := $(BUILDDIR)/lib/txt2c/txt2c
 
 # build txt2c directly and without our link libraries (none are required)
-$(TXT2C): $(TXT2C).c
+$(TXT2C): lib/txt2c/txt2c.c
+	@$(call MKDIR,$(dir $@))
 	$(CC_NATIVE) $^ -o $@
 
 # mark build products for cleaning
@@ -156,7 +172,8 @@ endif
 #   The C symbol name will be FOO_xyz.
 #   This is used to convert HTML and JavaScript to C sources.
 #   The implicit rule will then compile them to FOO.xyz.o.
-src/common/gen-%.c:: webgui/% | $(TXT2C)
+$(BUILDDIR)/src/common/gen-%.c:: webgui/% | $(TXT2C)
+	@$(call MKDIR,$(dir $@))
 	$(TXT2C) $< $@ $(subst .,_,$(notdir $<))
 
 # `make buildtest` builds the test-case executables but does not run them
@@ -169,7 +186,8 @@ test: buildtest
 	$(foreach test, $(TESTS), @echo $(test):$(newline)@$(test)$(newline))
 
 # rule to make test-case executables from their sources
-test/ardop/test_%: test/ardop/test_%.c $(OBJS) $(TEST_OBJS_COMMON)
+$(BUILDDIR)/test/ardop/test_%: test/ardop/test_%.c $(OBJS) $(TEST_OBJS_COMMON)
+	@$(call MKDIR,$(dir $@))
 	$(CC) \
 		$(CPPFLAGS) \
 		$(CFLAGS) \
@@ -189,45 +207,33 @@ test/ardop/test_%: test/ardop/test_%.c $(OBJS) $(TEST_OBJS_COMMON)
 #
 #   for tests that need mock functions injected,
 #   set WRAP to a space-separated list of functions to mock
-test/ardop/test_log: OBJS := \
-	src/common/log_file.o \
-	src/common/log.o
-test/ardop/test_log: WRAP := fopen fclose fwrite fflush freopen
-test/ardop/test_ARDOPCommon_processargs: WRAP := \
+$(BUILDDIR)/test/ardop/test_log: OBJS := \
+	$(BUILDDIR)/src/common/log_file.o \
+	$(BUILDDIR)/src/common/log.o
+$(BUILDDIR)/test/ardop/test_log: WRAP := fopen fclose fwrite fflush freopen
+$(BUILDDIR)/test/ardop/test_ARDOPCommon_processargs: WRAP := \
 	printf puts ardop_log_start InitAudio \
 	GetCM108Strlist GetSerialStrlist updateWebGuiNonAudioConfig \
 	OpenCOMPort tcpconnect OpenCM108 OpenSoundCapture OpenSoundPlayback \
 
--include *.d
+# Implicit rules to build object files in build directory
+$(BUILDDIR)/%.o: %.c
+	@$(call MKDIR,$(dir $@))
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
+
+-include $(BUILDDIR)/**/*.d
 
 # 'make clean' deletes files produced by the build process.
 # After using git checkout change branches, it is sometimes neccessary to run
 # 'make clean' before running 'make' to produce a successful build.  Failure
 # to run 'make clean' before using git checkout may sometimes leave build
 # related files that must then be manually deleted.
-CLEAN += \
-	ardopcf \
-	ardopcf.exe \
-	$(OBJS) \
-	$(OBJS:.o=.d) \
-	$(OBJS_LIN) \
-	$(OBJS_LIN:.o=.d) \
-	$(OBJS_WIN) \
-	$(OBJS_WIN:.o=.d) \
-	$(OBJS_EXE) \
-	$(OBJS_EXE:.o=.d) \
-	$(TESTS) \
-	$(TESTS:%=%.exe) \
-	$(TESTS:%=%.d) \
-	$(TEST_OBJS_COMMON) \
-	$(TEST_OBJS_COMMON:.o=.d) \
-	output.map \
 
 ifeq ($(OS),Windows_NT)
-# on Windows, del requires backslash paths
+# on Windows, use rmdir for directories
 clean :
-	del /Q /F $(subst /,\,$(CLEAN))
+	@if exist build rmdir /S /Q build
 else
 clean :
-	rm -f -- $(CLEAN)
+	rm -rf build
 endif

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ endef
 CPPFLAGS += -Isrc -Ilib
 CFLAGS = -g -MMD
 LDLIBS = -lm -lpthread
-LDFLAGS = -Xlinker -Map=output.map
+LDFLAGS = -Xlinker -Map=$(BUILDDIR)/output.map
 CC = gcc
 CC_NATIVE ?= $(CC)
 
@@ -221,7 +221,8 @@ $(BUILDDIR)/%.o: %.c
 	@$(call MKDIR,$(dir $@))
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
--include $(BUILDDIR)/**/*.d
+# Include dependency files
+-include $(OBJS:.o=.d) $(OBJS_EXE:.o=.d) $(TEST_OBJS_COMMON:.o=.d)
 
 # 'make clean' deletes files produced by the build process.
 # After using git checkout change branches, it is sometimes neccessary to run

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -12,13 +12,17 @@ By making the source code for **ardopcf** available with only the minimal restri
 
 No.  You do not need programming experience to build **ardopcf** from source.  One of the design goals of **ardopcf** is to make building from source as simple as possible.  If you have difficulty with the following instructions, please join the free users subgroup of ardop.groups.io and ask for help.
 
-## Does **ardopcf** work with my hardware and operating system.
+## Does **ardopcf** work with my hardware and operating system
 
 **ardopcf** is built and tested on computers with Intel/AMD processors having 32-bit and 64-bit Windows operating systems.  It is also built and tested on computers having Linux operating systems including those with Intel/AMD and ARM processors.  Specifically, Raspberry Pi Zero W and Zero 2W computers are used to build and test **ardopcf** for ARM processors.  Users have reported success building and using **ardopcf** on some addional Linux machines.
 
 I don't know whether anyone has tried building **ardopcf** for macOS or any other operating system.  Anyone who attempts to build for another OS is encouraged to send a message to the free users subgroup of ardop.groups.io to let us know whether it worked.  If it didn't work well, perhaps someone from that group will be able to help.
 
-## Building ardopcf for Linux:
+## Build System Output Folder
+
+The build system outputs files to the `build/%TARGET_OS%` folder in the project root. Where Target OS is one of Linux or Windows. This is where you will find the ardopcf executable when the build completes.
+
+## Building ardopcf for Linux
 
 Building **ardopcf** from source mostly doesn't require root/admin privledges.  It does require `libasound2-dev` and several items installed via the `build-essential` meta-package.  `libasound2-dev` provides the development files for the ALSA sound system library.  `git` also provides a convenient way to download the **ardopcf** source code and choose the branch you want to build.  Since there are other ways to get the source code, `git` is not strictly required, but the instructions provided will assume that it is available.  Many Linux distributions install `build-essential` and `git`, but not `libasound2-dev` by default.  There may be a way to install these without root access, but if so, I am not familiar with it.  So, if you want to build **ardopcf** on a machine without root access and where these packages are not already installed, then I recommend that you ask your system administrator to install these them for you.  Then follow these instructions, skipping the first step.
 
@@ -56,36 +60,35 @@ make
 
 # 4. Verify that it worked.
 # If the build worked correctly, the following line should print the help screen.
-./ardopcf -h
+./build/linux/ardopcf -h
 
 # 5. Move the executable to a directory in your $PATH.
 
 # 5a. IF you have root access, and you want ardopcf to be available to all users, put it
 # in /usr/local/bin
-sudo cp ardopcf /usr/local/bin
+sudo cp ./build/linux/ardopcf /usr/local/bin
 
 # 5b. IF you do not have root access, then put it in your personal bin directory $HOME/bin.
 # It is possible that $HOME/bin does not exist.  If not, you will get an error like:
 # cp: cannot create regular file '/home/username/bin/ardopcf': No such file or directory
 # If that occurs do 'mkdir $HOME/bin' first, then try again.  In this case you probably
 # also need to logout and log back in before $HOME/bin will be added to your $PATH
-cp ardopcf $HOME/bin/ardopcf
+cp ./build/linux/ardopcf $HOME/bin/ardopcf
 
 # Now typing 'ardopcf -h' at the command line should work from any directory.
 ```
+
 See [USAGE_linux.md](USAGE_linux.md) for guidance on use of **ardopcf** with Linux.  This includes instructions for determining what command line options you should use.
 
-
-
-## Building ardopcf for Windows using MinGW:
+## Building ardopcf for Windows using MinGW
 
 It **is** possible to build and run **ardopcf** on a Windows computer without admin privledges.
 
 ### Downloading the ardopcf source code
 
-Unlike the instructions for building **ardopcf** for Linux, these instuctions will not use `git` to clone (download) the source code.  However, if you are interested in studying or making changes to the source code, you probably want to install and learn to use `git`.  Using `git` may also be advantageous if you intend to build from the `develop` branch to try changes that have been made to **ardopcf** since that last release.  In this case, using `git` allows you easily continue to track and use the latest version of the `develop` branch as further changes are made to it.  See https://git-scm.com/doc to learn more about `git` and https://git-scm.com/downloads/win to get the version for Windows.
+Unlike the instructions for building **ardopcf** for Linux, these instuctions will not use `git` to clone (download) the source code.  However, if you are interested in studying or making changes to the source code, you probably want to install and learn to use `git`.  Using `git` may also be advantageous if you intend to build from the `develop` branch to try changes that have been made to **ardopcf** since that last release.  In this case, using `git` allows you easily continue to track and use the latest version of the `develop` branch as further changes are made to it.  See <https://git-scm.com/doc> to learn more about `git` and <https://git-scm.com/downloads/win> to get the version for Windows.
 
-At https://github.com/pflarue/ardop click on the green `Code` button, and then on `Download ZIP`.  By default this will download the code from the master branch corresponding to the most recent release of **ardopcf**.  If you want to include changes made since the last release, then before clicking on `Code` click on `master` and select `develop` from the pulldown.  This may include improvements over the most recently released version, but it may also include changes that have not been tested as well as the released version.
+At <https://github.com/pflarue/ardop> click on the green `Code` button, and then on `Download ZIP`.  By default this will download the code from the master branch corresponding to the most recent release of **ardopcf**.  If you want to include changes made since the last release, then before clicking on `Code` click on `master` and select `develop` from the pulldown.  This may include improvements over the most recently released version, but it may also include changes that have not been tested as well as the released version.
 
 When the download is complete, use Windows File Explorer to find the zip file in the Downloads directory.  Right click on it and choose `Extract All...`.  Choose a suitable directory.  A path that has any spaces in it may cause problems, so choose one without any.  Consider using `C:\Users\<USERNAME>` which will create `C:\Users\<USERNAME>\ardop-master`.
 
@@ -95,14 +98,14 @@ The **ardopcf** source code can be compiled into 32-bit or 64-bit Windows native
 
 MinGW stands for Minimalist GNU for Windows.  It provides a compiler very similar to the GNU C compiler that is used on Linux systems, but which produces native Windows binaries.  Compared to using Microsoft's C compiler system, using MinGW makes it simpler to create a program like **ardopcf** which can run on both Linux and Windows.
 
-Several internet sites provide Pre-built toolchains and packages to simplify installing MinGW-64, the version of MinGW that produces 64-bit (or optionally 32-bit) windows native binaries.  I recommend using a Zip archive available from https://winlibs.com.  These are intended to be easy to install and use, and they are what are used to create the **ardopcf** release binaries.  There are a lot of different options available to download from that site.  **ardopcf** v1.0.4.1.3 for Windows is built with [Win64 GCC 14.2.0 (with POSIX threads) - without LLVM/Clang/LLD/LLDB](https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.1-12.0.0-ucrt-r2/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64ucrt-12.0.0-r2.zip) and [Win32 GCC 14.2.0 (with POSIX threads) - without LLVM/Clang/LLD/LLDB](https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.1-12.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-14.2.0-mingw-w64ucrt-12.0.0-r2.zip).  These are probably a good default choice to use.  All Windows 11 and most Windows 10 operating systems are 64-bit.  To find out if a Windows 10 operating system is 32 or 64 bit press the **Start** button and select **Settings**, click on **System** then on **About** and read the line starting with **System type**.  See the details below if you have a Windows system older than Windows 10.
+Several internet sites provide Pre-built toolchains and packages to simplify installing MinGW-64, the version of MinGW that produces 64-bit (or optionally 32-bit) windows native binaries.  I recommend using a Zip archive available from <https://winlibs.com>.  These are intended to be easy to install and use, and they are what are used to create the **ardopcf** release binaries.  There are a lot of different options available to download from that site.  **ardopcf** v1.0.4.1.3 for Windows is built with [Win64 GCC 14.2.0 (with POSIX threads) - without LLVM/Clang/LLD/LLDB](https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.1-12.0.0-ucrt-r2/winlibs-x86_64-posix-seh-gcc-14.2.0-mingw-w64ucrt-12.0.0-r2.zip) and [Win32 GCC 14.2.0 (with POSIX threads) - without LLVM/Clang/LLD/LLDB](https://github.com/brechtsanders/winlibs_mingw/releases/download/14.2.0posix-19.1.1-12.0.0-ucrt-r2/winlibs-i686-posix-dwarf-gcc-14.2.0-mingw-w64ucrt-12.0.0-r2.zip).  These are probably a good default choice to use.  All Windows 11 and most Windows 10 operating systems are 64-bit.  To find out if a Windows 10 operating system is 32 or 64 bit press the **Start** button and select **Settings**, click on **System** then on **About** and read the line starting with **System type**.  See the details below if you have a Windows system older than Windows 10.
 
 <details>
 <summary><b>Details for choosing an specific version of MinGW-64 from</b> https://winlibs.com.</summary>
 
 Using one of the MinGW-64 Zip archives linked above is an good default choice.  The following describes how to choose an alternative.  This may be appropriate if a newer version has been released since the last **ardopcf** release.
 
-The files available for download from https://winlibs.com are grouped by those based on the UCRT runtime followed by those based on the MSVCRT runtime.  Choose from the ones that use the UCRT runtime.  The UCRT runtime library that these require is a standard part of all Windows 10 and later operating systems.  If your operating system is Windows Vista SP2 up to Windows 8.1, you can get UCRT by manually installing the [Universal C Runtime update](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).  UCRT is a newer system that replaces MSVCRT.  It has better support for recent versions of Windows, and it conforms better to the standards that define how C compilers should work.  **ardopcf** has not been tested with MSVCRT.  Using MSVCRT **might** allow **ardopcf** to run on older Windows machines, or it might require modifications to the source code to work with that older system.
+The files available for download from <https://winlibs.com> are grouped by those based on the UCRT runtime followed by those based on the MSVCRT runtime.  Choose from the ones that use the UCRT runtime.  The UCRT runtime library that these require is a standard part of all Windows 10 and later operating systems.  If your operating system is Windows Vista SP2 up to Windows 8.1, you can get UCRT by manually installing the [Universal C Runtime update](https://support.microsoft.com/en-us/topic/update-for-universal-c-runtime-in-windows-c0514201-7fe6-95a3-b0a5-287930f3560c).  UCRT is a newer system that replaces MSVCRT.  It has better support for recent versions of Windows, and it conforms better to the standards that define how C compilers should work.  **ardopcf** has not been tested with MSVCRT.  Using MSVCRT **might** allow **ardopcf** to run on older Windows machines, or it might require modifications to the source code to work with that older system.
 
 Under UCRT runtime, the packages at the top of the list are the most recent, so choosing the first one on the list is usually a good choice.  Each version is available in Win32 and Win64 options.  As described above, all Windows 11 and most Windows 10 operating systems are 64-bit.
 
@@ -135,20 +138,20 @@ dir Makefile
 
 5. Verify that the build worked correctly.  The following line should print the help screen.
 
-`ardopcf -h`
+`build\windows\ardopcf -h`
 
 The first time that you run `ardopcf` without the `-h` option,  Windows will ask you whether you want to allow public and private networks to access this app.  Host programs like [Pat](https://getpat.io) use a TCP "network" connection to work with **ardopcf**.  Without a program like Pat, **ardopcf** isn't useful.  Also, the **ardopcf** WebGui connects from a browser window to **ardopcf** using a TCP "network" connection.  If you choose `Allow` in this windows dialog, then you will be able to use the Webgui in a browser running on any computer on your local network and/or run a host program on any computer on your local network.  If instead you choose 'Cancel' in this windows dialog, then these programs/features will still work, but only if they are all running on the same computer.  If you do not have admin privledges on this Windows computer, then `Allow` won't work.  On a Windows computer this usually isn't a problem since you probably intend to run everything on this one computer anyway.  The ability to run **ardopcf** on one computer and a host or the WebGui on another is more likely to be useful when **ardopcf** is running on a small computer like a Raspberry Pi that does not have a monitor conencted to it.
 
-6. You may leave `ardopcf.exe` where it is or copy or move it to a different directory.  The choice is yours.  One option is to put it in `C:\Users\<USERNAME>\ardop` and also create a `C:\Users\<USERNAME>\ardop\logs` directory for the log files that ardopcf creates.  If you copy `ardopcf.exe` to a directory other than where you built it from source, you may choose to delete the source directory and even the MinGW directory.
+6. You may leave `ardopcf.exe` where it is or copy or move it to a different directory.  The choice is yours.  One option is to put it in `C:\Users\<USERNAME>\ardop` and also create a `C:\Users\<USERNAME>\ardop\logs` directory for the log files that ardopcf creates.  If you copy `build\windows\ardopcf.exe` to a directory other than where you built it from source, you may choose to delete the source directory and even the MinGW directory.
 
 See [USAGE_windows.md](USAGE_windows.md) for guidance on use of **ardopcf** with Windows.  This includes instructions for determining what command line options you should use, how to set up a Desktop Shortcut to start **ardopcf**, and how to adjust your audio settings.
 
-
-## Building ardopcf for Windows by cross-compiling on a Linux machine:
+## Building ardopcf for Windows by cross-compiling on a Linux machine
 
 Before using Linux to cross-compile an executable for Windows, follow the instructions above to build ardopcf for Linux.
 
 Then:
+
 ```
 sudo apt install mingw-w64
 make CC_NATIVE=gcc CC=i686-w64-mingw32-gcc-posix WIN32=1

--- a/test/python/ardop_parameters.py
+++ b/test/python/ardop_parameters.py
@@ -3,7 +3,21 @@ This module provides some constants for use by other Python test modules.
 """
 
 # Path to the ardopcf executable
-APATH = "../../ardopcf"
+import os
+import platform
+import sys
+
+# Determine the platform-specific build directory
+if sys.platform.startswith('win') or os.name == 'nt':  # Windows
+    PLATFORM = "windows"
+    EXEC_EXT = ".exe"
+else:  # Linux/Unix/macOS
+    PLATFORM = "linux"
+    EXEC_EXT = ""
+
+# Use the build directory structure
+BUILDDIR = f"../../build/{PLATFORM}"
+APATH = f"{BUILDDIR}/ardopcf{EXEC_EXT}"
 # Suggested location for temporary files including WAV recordings
 # and log files.  WAV files written to this directory should be deleted
 # after they have been used.  However, when a test failure occurs, the


### PR DESCRIPTION
Fixes #159 

This PR refactors the build system to organize all build artifacts into a centralized build/ directory with platform-specific subdirectories, improving repository cleanliness and build management.

## Changes

### Build Directory Structure

- All build artifacts now go into build/$(PLATFORM)/ where PLATFORM is linux or windows
- Object files maintain their source directory structure within the build directory
- Cross-compilation properly uses target platform directory (e.g., make WIN32=1 uses build/windows/)

### Makefile Improvements

- Added platform detection that sets BUILDDIR to build/linux or build/windows
- Created platform-specific MKDIR function for Windows/Unix compatibility
- Updated all object file paths to use $(BUILDDIR) prefix
- Fixed linker map file location to $(BUILDDIR)/output.map
- Added .PRECIOUS directive to preserve generated C files

### Clean Targets

- make clean - Removes only the current platform's build directory
- make cleanall - Removes the entire build/ directory (all platforms)

### Python Test Fixes

- Updated test/python/ardop_parameters.py to automatically detect platform
- Python tests now look for executables in the correct build directory
- Windows: build/windows/ardopcf.exe
- Linux: build/linux/ardopcf

### Other Updates

- Simplified .gitignore to exclude entire /build/ directory
- Fixed dependency file inclusion to use standard Make syntax

Benefits

- Cleaner repository: All build artifacts contained in one location
- Platform separation: Easy to build for multiple platforms without conflicts
- Simplified cleanup: Single directory to remove instead of scattered files
- Better cross-compilation: Clear separation between host and target builds
- CI/CD ready: Organized structure makes automation easier

## Testing

- Tested native builds on Linux and Windows
- Verified make clean and make cleanall work correctly
- Confirmed Python tests find executables in build directories
- confirmed `make buildtest` also uses builddire
- confirmed `make test` works

## Migration Notes

After pulling this branch, run make clean using the old Makefile first to remove any existing build artifacts in the source tree, then build normally. All new artifacts will be created in the build/ directory.

Alternatively, if you have no other active changes, you'll immediately notice a bunch of "changes" in yoru IDE. You can delete those old build artifacts.

If in doubt, just compare your local filesystem to the GitHub repo online.