### PR TITLE
Fix compiler error, add MacOS gitignore items, adjust import paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ newArdopSampleArrays.c
 
 # Editor garbage
 /.vscode/**
+# Editor backup files
+*~
+
+# MacOS attribute files
+.DS_Store
+

--- a/lib/rockliff/rrs.c
+++ b/lib/rockliff/rrs.c
@@ -521,7 +521,8 @@ int decode_rs(int *rcvd, int rslen, bool quiet, bool test_only)
 int init_rs(int *lengths, int count) {
 	generate_gf();
 	if (gen_polys(lengths, count) != 0)
-		return (1);
+		return 1;
+	return 0;
 }
 
 /*	While only the first datalen bytes of data contain the data to be

--- a/src/common/Locator.c
+++ b/src/common/Locator.c
@@ -1,11 +1,11 @@
-#include "common/Locator.h"
+#include "Locator.h"
 
 #include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
 
-#include "common/log.h"
+#include "log.h"
 
 // Legacy ARDOPC used to transmit "No GS" in IDFRAMEs to indicate
 // that the grid square is unset. This is *not* valid as a

--- a/src/common/Modulate.c
+++ b/src/common/Modulate.c
@@ -15,11 +15,11 @@
 #include <stdbool.h>
 
 #include "os_util.h"
-#include "common/ARDOPC.h"
-#include "common/ardopcommon.h"
-#include "common/wav.h"
-#include "common/ptt.h"
-#include "common/audio.h"
+#include "ARDOPC.h"
+#include "ardopcommon.h"
+#include "wav.h"
+#include "ptt.h"
+#include "audio.h"
 
 // pttOnTime is used both as a reference for how long audio has been playing
 // and as an indication of whether or not any transmissions have been made

--- a/src/common/ardopcf.c
+++ b/src/common/ardopcf.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 
-#include "common/log.h"
-#include "common/audio.h"
+#include "log.h"
+#include "audio.h"
 #include "rockliff/rrs.h"
 
 extern char DecodeWav[5][256];

--- a/src/common/eutf8.c
+++ b/src/common/eutf8.c
@@ -3,8 +3,8 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "common/log.h"
-#include "common/eutf8.h"
+#include "log.h"
+#include "eutf8.h"
 
 // See https://GitHub.com/pflarue/eutf8 for a full description of eutf8 (escaped
 // UTF-8) encoding along with reference implementations of to_eutf() and


### PR DESCRIPTION
I'm trying a bit to build ardopcf for iOS (iPhone/iPad). Here's a couple of small initial trivial things. The missing "return 0" is a fatal error by default on this compiler, and the include paths don't need to have a "common/" prefix if they're in the same directory with the .c file.

- Hessu / OH7LZB