### PR TITLE
Remove unnecessary path from #include statements

### DIFF
--- a/src/common/ARDOPC.c
+++ b/src/common/ARDOPC.c
@@ -29,14 +29,14 @@ const char ProductName[] = "ardopcf";
 #define closesocket close
 #endif
 
-#include "common/os_util.h"
-#include "common/audio.h"
-#include "common/ARDOPC.h"
-#include "common/Locator.h"
-#include "common/StationId.h"
-#include "common/wav.h"
-#include "common/Modulate.h"
-#include "common/Webgui.h"
+#include "os_util.h"
+#include "audio.h"
+#include "ARDOPC.h"
+#include "Locator.h"
+#include "StationId.h"
+#include "wav.h"
+#include "Modulate.h"
+#include "Webgui.h"
 #include "rockliff/rrs.h"
 
 UCHAR bytDataToSend[DATABUFFERSIZE];

--- a/src/common/ARDOPC.h
+++ b/src/common/ARDOPC.h
@@ -3,9 +3,9 @@
 
 #include <stdbool.h>
 
-#include "common/log.h"
-#include "common/Locator.h"
-#include "common/StationId.h"
+#include "log.h"
+#include "Locator.h"
+#include "StationId.h"
 
 extern const char ProductName[];
 extern const char ProductVersion[];

--- a/src/common/ARDOPCommon.c
+++ b/src/common/ARDOPCommon.c
@@ -2,10 +2,10 @@
 // This simplifies test builds with using local version numbers independent
 //   of version numbers pushed to git repository.
 #include "os_util.h"
-#include "common/version.h"
-#include "common/audio.h"
-#include "common/Webgui.h"
-#include "common/ptt.h"
+#include "version.h"
+#include "audio.h"
+#include "Webgui.h"
+#include "ptt.h"
 
 
 void PollReceivedSamples();
@@ -36,8 +36,8 @@ void PollReceivedSamples();
 #include <ctype.h>
 #include <getopt.h>
 
-#include "common/ardopcommon.h"
-#include "common/wav.h"
+#include "ardopcommon.h"
+#include "wav.h"
 
 void ProcessCommandFromHost(char * strCMD);
 

--- a/src/common/ARQ.c
+++ b/src/common/ARQ.c
@@ -13,10 +13,10 @@
 
 #include <time.h>
 
-#include "common/os_util.h"
-#include "common/ARDOPC.h"
-#include "common/Modulate.h"
-#include "common/eutf8.h"
+#include "os_util.h"
+#include "ARDOPC.h"
+#include "Modulate.h"
+#include "eutf8.h"
 
 extern unsigned int PKTLEDTimer;
 extern UCHAR bytData[];

--- a/src/common/BusyDetect.c
+++ b/src/common/BusyDetect.c
@@ -7,8 +7,8 @@
 #include <windows.h>
 #endif
 
-#include "common/os_util.h"
-#include "common/ARDOPC.h"
+#include "os_util.h"
+#include "ARDOPC.h"
 
 VOID SortSignals2(float * dblMag, int intStartBin, int intStopBin, int intNumBins, float *  dblAVGSignalPerBin, float *  dblAVGBaselinePerBin);
 

--- a/src/common/FEC.c
+++ b/src/common/FEC.c
@@ -2,11 +2,11 @@
 
 #include <stdbool.h>
 
-#include "common/os_util.h"
-#include "common/ARDOPC.h"
-#include "common/ardopcommon.h"
-#include "common/ptt.h"
-#include "common/Modulate.h"
+#include "os_util.h"
+#include "ARDOPC.h"
+#include "ardopcommon.h"
+#include "ptt.h"
+#include "Modulate.h"
 
 extern bool blnAbort;
 

--- a/src/common/HostInterface.c
+++ b/src/common/HostInterface.c
@@ -3,13 +3,13 @@
 
 #include <stdbool.h>
 
-#include "common/ARDOPC.h"
-#include "common/ardopcommon.h"
-#include "common/audio.h"
-#include "common/wav.h"
-#include "common/ptt.h"  // PTT and CAT
-#include "common/Webgui.h"
-#include "common/eutf8.h"
+#include "ARDOPC.h"
+#include "ardopcommon.h"
+#include "audio.h"
+#include "wav.h"
+#include "ptt.h"  // PTT and CAT
+#include "Webgui.h"
+#include "eutf8.h"
 
 bool blnHostRDY = false;
 extern int intFECFramesSent;

--- a/src/common/Locator.h
+++ b/src/common/Locator.h
@@ -3,8 +3,8 @@
 
 #include <stdint.h>
 
-#include "common/mustuse.h"
-#include "common/Packed6.h"
+#include "mustuse.h"
+#include "Packed6.h"
 
 /**
  * @def LOCATOR_SIZE

--- a/src/common/Packed6.c
+++ b/src/common/Packed6.c
@@ -1,4 +1,4 @@
-#include "common/Packed6.h"
+#include "Packed6.h"
 
 #include <string.h>
 #include <stdio.h>

--- a/src/common/Packed6.h
+++ b/src/common/Packed6.h
@@ -5,7 +5,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include "common/mustuse.h"
+#include "mustuse.h"
 
 /**
  * @def PACKED6_SIZE

--- a/src/common/RXO.c
+++ b/src/common/RXO.c
@@ -1,9 +1,9 @@
 #include <stdbool.h>
 
-#include "common/ARDOPC.h"
-#include "common/ardopcommon.h"
-#include "common/RXO.h"
-#include "common/eutf8.h"
+#include "ARDOPC.h"
+#include "ardopcommon.h"
+#include "RXO.h"
+#include "eutf8.h"
 
 extern UCHAR bytSessionID;
 extern UCHAR bytFrameData1[760];

--- a/src/common/RXO.h
+++ b/src/common/RXO.h
@@ -1,5 +1,5 @@
 #include <stdbool.h>
-#include "common/ARDOPC.h"
+#include "ARDOPC.h"
 
 float RxoComputeDecodeDistance(int * intToneMags, UCHAR bytFrameType);
 bool RxoDecodeSessionID(UCHAR bytFrameType, int * intToneMags, float dblMaxDistance);

--- a/src/common/SoundInput.c
+++ b/src/common/SoundInput.c
@@ -7,15 +7,15 @@
 
 #include <stdbool.h>
 
-#include "common/os_util.h"
-#include "common/ARDOPC.h"
-#include "common/Modulate.h"
-#include "common/wav.h"
-#include "common/Locator.h"
-#include "common/RXO.h"
-#include "common/sdft.h"
-#include "common/Webgui.h"
-#include "common/eutf8.h"
+#include "os_util.h"
+#include "ARDOPC.h"
+#include "Modulate.h"
+#include "wav.h"
+#include "Locator.h"
+#include "RXO.h"
+#include "sdft.h"
+#include "Webgui.h"
+#include "eutf8.h"
 #include "rockliff/rrs.h"
 
 #pragma warning(disable : 4244)  // Code does lots of float to int

--- a/src/common/StationId.c
+++ b/src/common/StationId.c
@@ -1,11 +1,11 @@
-#include "common/StationId.h"
+#include "StationId.h"
 
 #include <assert.h>
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
 
-#include "common/log.h"
+#include "log.h"
 
 // minimum number of characters in a callsign
 #define CALLSIGN_MIN 2

--- a/src/common/StationId.h
+++ b/src/common/StationId.h
@@ -3,8 +3,8 @@
 
 #include <stdint.h>
 
-#include "common/mustuse.h"
-#include "common/Packed6.h"
+#include "mustuse.h"
+#include "Packed6.h"
 
 /**
  * @def STATIONID_CALL_SIZE

--- a/src/common/TCPHostInterface.c
+++ b/src/common/TCPHostInterface.c
@@ -41,9 +41,9 @@ int _memicmp(unsigned char *a, unsigned char *b, int n);
 
 #define MAX_PENDING_CONNECTS 4
 
-#include "common/os_util.h"
-#include "common/ARDOPC.h"
-#include "common/ptt.h"  // PTT and CAT
+#include "os_util.h"
+#include "ARDOPC.h"
+#include "ptt.h"  // PTT and CAT
 
 #define GetBuff() _GetBuff(__FILE__, __LINE__)
 #define ReleaseBuffer(s) _ReleaseBuffer(s, __FILE__, __LINE__)

--- a/src/common/Webgui.c
+++ b/src/common/Webgui.c
@@ -2,12 +2,12 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
-#include "common/os_util.h"
-#include "common/ardopcommon.h"
-#include "common/StationId.h"
-#include "common/audio.h"
-#include "common/ptt.h"
-#include "common/Webgui.h"
+#include "os_util.h"
+#include "ardopcommon.h"
+#include "StationId.h"
+#include "audio.h"
+#include "ptt.h"
+#include "Webgui.h"
 #include "ws_server/ws_server.h"
 
 

--- a/src/common/Webgui.h
+++ b/src/common/Webgui.h
@@ -1,7 +1,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 
-#include "common/ardopcommon.h"
+#include "ardopcommon.h"
 
 extern int WebGuiNumConnected;
 

--- a/src/common/ardopcommon.h
+++ b/src/common/ardopcommon.h
@@ -1,4 +1,4 @@
-#include "common/ARDOPC.h"
+#include "ARDOPC.h"
 
 #ifndef ARDOPCOMMONDEFINED
 #define ARDOPCOMMONDEFINED

--- a/src/common/log.c
+++ b/src/common/log.c
@@ -1,4 +1,4 @@
-#include "common/log.h"
+#include "log.h"
 
 #include <assert.h>
 #include <string.h>
@@ -12,7 +12,7 @@
 #define LOG_OUTPUT_SYSLOG
 #endif
 
-#include "common/log_file.h"
+#include "log_file.h"
 
 // Configure log decoration, see zf_log.c
 #define ZF_LOG_MESSAGE_CTX_FORMAT (\

--- a/src/common/log_file.c
+++ b/src/common/log_file.c
@@ -1,4 +1,4 @@
-#include "common/log_file.h"
+#include "log_file.h"
 
 #include <errno.h>
 #include <limits.h>
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <sys/time.h>
 
-#include "common/log.h"
+#include "log.h"
 
 /* emit inline symbol */
 extern bool ardop_logfile_need_rollover(

--- a/src/common/log_file.h
+++ b/src/common/log_file.h
@@ -15,7 +15,7 @@
 #include <stdio.h>
 #include <time.h>
 
-#include "common/mustuse.h"
+#include "mustuse.h"
 
 // Flooring integer division
 //

--- a/src/common/mustuse.h
+++ b/src/common/mustuse.h
@@ -12,7 +12,7 @@
  * which must be checked.
  *
  * \code
- * #include "common/mustuse.h"
+ * #include "mustuse.h"
  *
  * ARDOP_MUSTUSE bool this_function_can_fail(int in, int* out);
  * \endcode

--- a/src/common/ptt.c
+++ b/src/common/ptt.c
@@ -10,12 +10,12 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "common/os_util.h"
-#include "common/ardopcommon.h"
-#include "common/ptt.h"
-#include "common/log.h"
-#include "common/Webgui.h"
-#include "common/txframe.h"
+#include "os_util.h"
+#include "ardopcommon.h"
+#include "ptt.h"
+#include "log.h"
+#include "Webgui.h"
+#include "txframe.h"
 
 #define PTTNONCATMASK 0x0F
 #define PTTCATMASK 0x30

--- a/src/common/sdft.c
+++ b/src/common/sdft.c
@@ -2,8 +2,8 @@
 #include <complex.h>
 #include <math.h>
 
-#include "common/ardopcommon.h"
-#include "common/sdft.h"
+#include "ardopcommon.h"
+#include "sdft.h"
 
 // For validation/debugging only
 void GoertzelRealImag(short intRealIn[], int intPtr, int N, float m, float * dblReal, float * dblImag);

--- a/src/common/txframe.c
+++ b/src/common/txframe.c
@@ -12,9 +12,9 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "common/ARDOPC.h"
-#include "common/Locator.h"
-#include "common/Modulate.h"
+#include "ARDOPC.h"
+#include "Locator.h"
+#include "Modulate.h"
 
 extern int intLastRcvdFrameQuality;  // defined in ARDOPC.c
 

--- a/src/common/wav.c
+++ b/src/common/wav.c
@@ -2,8 +2,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "common/ardopcommon.h"
-#include "common/wav.h"
+#include "ardopcommon.h"
+#include "wav.h"
 
 // PCM WAV file header
 char WavHeader[] = {


### PR DESCRIPTION
Further cleanup of unnecessary paths from #include statements to header files in the same directory.  @hessu identified this issue and began the cleanup in PR #166.