### PR TITLE
ci: build/test on Linux & Windows; upload zipped artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,13 +75,24 @@ jobs:
         uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
-          update: true
-          install: >-
-            base-devel
-            mingw-w64-x86_64-gcc
-            mingw-w64-x86_64-make
-            mingw-w64-x86_64-cmocka
-            zip
+          update: false
+
+      - name: Update and install dependencies (retry)
+        shell: msys2 {0}
+        run: |
+          set -e
+          for attempt in 1 2 3; do
+            if pacman --noconfirm --needed --overwrite '*' --disable-download-timeout -Syu \
+              base-devel \
+              mingw-w64-x86_64-gcc \
+              mingw-w64-x86_64-make \
+              mingw-w64-x86_64-cmocka \
+              zip; then
+              break
+            fi
+            echo "pacman failed (attempt ${attempt}), retrying in 10s..." >&2
+            sleep 10
+          done
 
       - name: Build
         shell: msys2 {0}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,123 @@
+##
+## Ardop Build Workflow
+##
+## - Builds on Ubuntu and Windows using the Makefile.
+## - Linux: installs build-essential, libasound2-dev, libcmocka-dev; builds and runs unit tests.
+## - Windows: uses MSYS2 MinGW toolchain with cmocka; builds and runs unit tests.
+## - Artifacts: zips only the built binary and uploads to the run.
+##   Filename format: {os}-{arch}-ardopcf-{commit}.zip where:
+##     - {os} is linux|windows
+##     - {arch} is normalized (amd64, arm64, 386, armv7, armv6)
+##     - {commit} is the 7-char short GITHUB_SHA
+##
+
+name: Build
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  linux:
+    name: Build (Ubuntu)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential libasound2-dev libcmocka-dev zip
+
+      - name: Build
+        run: make -j$(nproc)
+
+      - name: Run unit tests
+        run: make test
+
+      - name: Package artifact
+        id: package
+        run: |
+          BIN=build/linux/ardopcf
+          test -f "$BIN" || { echo "Binary not found: $BIN"; exit 1; }
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64|amd64) ARCH=amd64 ;;
+            aarch64|arm64) ARCH=arm64 ;;
+            i386|i686) ARCH=386 ;;
+            armv7l|armv7) ARCH=armv7 ;;
+            armv6l) ARCH=armv6 ;;
+            *) : ;;
+          esac
+          GIT_SHA=${GITHUB_SHA::7}
+          ZIP="linux-${ARCH}-ardopcf-${GIT_SHA}.zip"
+          zip -j "$ZIP" "$BIN"
+          echo "artifact=$ZIP" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.artifact }}
+          path: ${{ steps.package.outputs.artifact }}
+
+  windows:
+    name: Build (Windows)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up MSYS2 (MINGW64)
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            base-devel
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-make
+            mingw-w64-x86_64-cmocka
+            zip
+
+      - name: Build
+        shell: msys2 {0}
+        run: |
+          make WIN32=1 -j$(nproc)
+
+      - name: Run unit tests
+        shell: msys2 {0}
+        run: |
+          make WIN32=1 test
+
+      - name: Package artifact
+        id: package
+        shell: msys2 {0}
+        run: |
+          BIN=build/windows/ardopcf.exe
+          if [ ! -f "$BIN" ]; then
+            # Fallback in case the toolchain emitted without .exe
+            [ -f build/windows/ardopcf ] && BIN=build/windows/ardopcf || { echo "Binary not found"; exit 1; }
+          fi
+          ARCH=$(uname -m)
+          case "$ARCH" in
+            x86_64|amd64) ARCH=amd64 ;;
+            aarch64|arm64) ARCH=arm64 ;;
+            i386|i686) ARCH=386 ;;
+            armv7l|armv7) ARCH=armv7 ;;
+            armv6l) ARCH=armv6 ;;
+            *) : ;;
+          esac
+          GIT_SHA=${GITHUB_SHA::7}
+          ZIP="windows-${ARCH}-ardopcf-${GIT_SHA}.zip"
+          zip -j "$ZIP" "$BIN"
+          echo "artifact=$ZIP" >> "$GITHUB_OUTPUT"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.artifact }}
+          path: ${{ steps.package.outputs.artifact }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,7 +82,14 @@ jobs:
         run: |
           set -e
           for attempt in 1 2 3; do
-            if pacman --noconfirm --needed --overwrite '*' --disable-download-timeout -Syu \
+            if pacman --noconfirm --disable-download-timeout -Sy; then
+              break
+            fi
+            echo "pacman -Sy failed (attempt ${attempt}), retrying in 10s..." >&2
+            sleep 10
+          done
+          for attempt in 1 2 3; do
+            if pacman --noconfirm --needed --overwrite '*' --disable-download-timeout -S \
               base-devel \
               mingw-w64-x86_64-gcc \
               mingw-w64-x86_64-make \

--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,11 @@ $(BUILDDIR)/test/ardop/test_log: WRAP := fopen fclose fwrite fflush freopen
 $(BUILDDIR)/test/ardop/test_ARDOPCommon_processargs: WRAP := \
 	printf puts ardop_log_start InitAudio \
 	GetCM108Strlist GetSerialStrlist updateWebGuiNonAudioConfig \
-	OpenCOMPort tcpconnect OpenCM108 OpenSoundCapture OpenSoundPlayback \
+	OpenCOMPort tcpconnect OpenCM108 OpenSoundCapture OpenSoundPlayback
+ifneq ($(WIN32),)
+# MinGW maps printf/puts to __mingw_printf/__mingw_puts when ANSI stdio is enabled
+$(BUILDDIR)/test/ardop/test_ARDOPCommon_processargs: WRAP += __mingw_printf __mingw_puts
+endif
 
 # Implicit rules to build object files in build directory
 $(BUILDDIR)/%.o: %.c

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,12 @@ BUILDDIR := build/$(PLATFORM)
 
 # Platform-specific directory creation
 ifeq ($(OS),Windows_NT)
+# On Windows, prefer POSIX-style mkdir when running under MSYS/MinGW shells
+ifneq ($(MSYSTEM),)
+MKDIR = mkdir -p $1
+else
 MKDIR = if not exist "$(subst /,\,$1)" mkdir "$(subst /,\,$1)"
+endif
 else
 MKDIR = mkdir -p $1
 endif
@@ -234,11 +239,18 @@ $(BUILDDIR)/%.o: %.c
 # related files that must then be manually deleted.
 
 ifeq ($(OS),Windows_NT)
-# on Windows, use rmdir for directories
+ifneq ($(MSYSTEM),)
+clean :
+	rm -rf $(BUILDDIR)
+cleanall :
+	rm -rf build
+else
+# on native cmd.exe shells, use rmdir for directories
 clean :
 	@if exist "$(subst /,\,$(BUILDDIR))" rmdir /S /Q "$(subst /,\,$(BUILDDIR))"
 cleanall :
 	@if exist build rmdir /S /Q build
+endif
 else
 clean :
 	rm -rf $(BUILDDIR)

--- a/test/ardop/test_ARDOPCommon_processargs.c
+++ b/test/ardop/test_ARDOPCommon_processargs.c
@@ -132,6 +132,38 @@ int __wrap_puts(const char *s) {
 	return __real_puts(s);
 }
 
+// MinGW uses __mingw_printf/puts when ANSI stdio is enabled; wrap them too.
+int __wrap___mingw_printf(const char *restrict format, ...) {
+	(void) format;
+	if (++printindex == MAXPRINTSTRS) {
+		__real_printf("P MAXPRINTSTRS exceeded.  Unable to store additional text.\n");
+		return 1;
+	}
+	printstrs[printindex][0] = 'P';
+	va_list args;
+	va_start(args, format);
+	vsnprintf(&(printstrs[printindex][1]), MAXSTRLEN - 1, format, args);
+	if (suppressprintf) {
+		va_end(args);
+		return strlen(printstrs[printindex]);
+	}
+	int ret = vprintf(format, args);
+	va_end(args);
+	return ret;
+}
+
+int __wrap___mingw_puts(const char *s) {
+	if (++printindex == MAXPRINTSTRS) {
+		__real_printf("S MAXPRINTSTRS exceeded.  Unable to store additional text.\n");
+		return 1;
+	}
+	printstrs[printindex][0] = 'S';
+	snprintf(&(printstrs[printindex][1]), MAXSTRLEN - 1, "%s", s);
+	if (suppressprintf)
+		return strlen(s);
+	return __real_puts(s);
+}
+
 static void test_callback(const zf_log_message *msg, void *arg) {
 	(void) arg;  // This line avoids an unused parameter warning
 	if (++printindex == MAXPRINTSTRS) {


### PR DESCRIPTION


# Summary

Add cross-platform CI to build and test on Ubuntu and Windows, then upload zipped binaries per commit. Ensure changes compile and pass tests on Linux and Windows consistently. Provide easily identifiable, per-commit artifacts for testing and sharing.

## What’s Included

- .github/workflows/build.yaml:1: New workflow that:
  - Builds via make and runs unit tests via make test on both OSes.
  - Uses MSYS2 MinGW on Windows (with cmocka).
  - Packages only the compiled binary and uploads it as an artifact.

## Artifacts

- Filename format: {os}-{arch}-ardopcf-{commit}.zip
  - os: linux or windows
  - arch: normalized (amd64, arm64, 386, armv7, armv6)
  - commit: 7-char short GITHUB_SHA
- Contents: a single file — build/linux/ardopcf or build/windows/ardopcf.exe.

## Triggers

- push to any branch, pull_request, and manual workflow_dispatch.
- Note: tags are not included (no release flow yet).

How To Verify

- Push a branch or open a PR; visit Actions → “Build”.
- Confirm both jobs pass and two artifacts are uploaded with expected names.
- Optionally unzip and run:
  - Linux: ./ardopcf -h
  - Windows: ardopcf.exe -h

## Notes

- macOS builds are intentionally excluded; will be handled in a separate branch once this core support is in develop.
- Windows tests are enabled via mingw-w64-x86_64-cmocka.