### PR TITLE
macos: filter Apple-internal /dev/cu.* nodes from serial device list

### DIFF
--- a/src/macos/os_util.c
+++ b/src/macos/os_util.c
@@ -3,7 +3,8 @@
 // The timing, signal handling, serial (COM) port, and TCP helpers shared with
 // the Linux backend live in src/unix/os_util.c.  This file holds only the parts
 // that differ on macOS: CM108 HID PTT (not supported) and serial device
-// enumeration (which scans /dev/cu.*).
+// enumeration (which scans /dev/cu.*, skipping Apple-internal debug/Bluetooth
+// nodes that are present on every Mac but unusable for CAT/PTT).
 
 #include <dirent.h>
 #include <errno.h>
@@ -76,11 +77,35 @@ char** GetSerialStrlist() {
 			pathstr, strerror(errno));
 		return slist;
 	}
+	// Apple-internal /dev/cu.* nodes that are not usable for CAT/PTT.  These
+	// are exposed by macOS system services (Bluetooth SPP listener, kernel
+	// debug console, Wi-Fi driver debug channel) rather than by IOKit
+	// IOSerialBSDClient, so they show up in a raw /dev scan but are not real
+	// serial adapters.  cu.wlan-debug is Apple-silicon-only; the other two
+	// are present on every modern Mac.
+	static const char * const macos_internal_serial_devices[] = {
+		"cu.Bluetooth-Incoming-Port",
+		"cu.debug-console",
+		"cu.wlan-debug",
+		NULL
+	};
 	while ((dir = readdir(d)) != NULL) {
 		if (dir->d_type == DT_DIR || dir->d_name[0] == '.')
 			continue;
 		if (strncmp("cu.", dir->d_name, strlen("cu.")) != 0)
 			continue;  // not a callout serial port
+		bool is_internal = false;
+		for (int i = 0; macos_internal_serial_devices[i] != NULL; i++) {
+			if (strcmp(dir->d_name, macos_internal_serial_devices[i]) == 0) {
+				is_internal = true;
+				break;
+			}
+		}
+		if (is_internal) {
+			ZF_LOGD("Skipping macOS-internal serial device %s%s",
+				pathstr, dir->d_name);
+			continue;
+		}
 		if (slist == NULL) {
 			if ((slist = (char **) malloc(sizeof(char *))) == NULL) {
 				ZF_LOGE("Error from malloc() in GetSerialStrlist() (%s)",


### PR DESCRIPTION
Closes #177.

## Summary

`GetSerialStrlist()` in `src/macos/os_util.c` previously included three Apple-internal `/dev/cu.*` device nodes in its output:

- `cu.Bluetooth-Incoming-Port` — Bluetooth SPP listener, present on every modern Mac
- `cu.debug-console` — kernel debug console, present on every modern Mac
- `cu.wlan-debug` — Wi-Fi driver debug channel, Apple-silicon only

These are exposed by macOS system services (not IOKit `IOSerialBSDClient`), show up in a raw `/dev` scan, but cannot be used for CAT or PTT. Users see them in the WebGui and host-command listings and reasonably ask "why doesn't this one work?"

## Approach

Added a small `static const` block-list inside `GetSerialStrlist()` after the existing `cu.` prefix check, and an exact-match `strcmp` loop that `continue`s past matches. Exact match rather than prefix match keeps the filter conservative — a real USB adapter with an unlucky name would still be listed.

Emits `ZF_LOGD` on skip so the reason is visible in debug traces.

## Alternative considered

A pure IOKit-based filter using service classes would exclude these devices without a hard-coded list, but that would be a bigger refactor than the issue asks for and would change the file's approach materially. The block-list approach fits the existing `readdir`-based enumeration style with 26 added lines.

## Local verification (macOS 26.4, Apple Silicon M1)

Build: clean, no new warnings.

Runtime (`ardopcf -l /tmp/logs -G 0`, then log tail):

```
18:19:18.486 D Skipping macOS-internal serial device /dev/cu.debug-console
18:19:18.486 D Skipping macOS-internal serial device /dev/cu.Bluetooth-Incoming-Port
```

Both internal nodes present on this machine are correctly skipped. No `cu.wlan-debug` exists on this specific Mac, but the code path is identical for all three entries in the list.

With no USB serial adapter attached, `GetSerialStrlist()` returns `NULL` (`LogStrlist` gates on `NULL` so no empty `Serial Devices:` header is logged). Behaviour matches user expectations.

— jjones9527 / MacWinlink