### PR TITLE
macos: expose CoreAudio device UID via DeviceInfo.alias

### DIFF
--- a/src/macos/CoreAudio.c
+++ b/src/macos/CoreAudio.c
@@ -250,6 +250,24 @@ static char *device_name(AudioDeviceID devid) {
 	return out;
 }
 
+// Convert an owned CFStringRef to a freshly-allocated UTF-8 C string.
+// Returns NULL on failure.  Does NOT release the input CFStringRef —
+// the caller retains that responsibility.
+static char *cfstring_to_utf8(CFStringRef s) {
+	if (s == NULL)
+		return NULL;
+	CFIndex len = CFStringGetMaximumSizeForEncoding(
+		CFStringGetLength(s), kCFStringEncodingUTF8) + 1;
+	char *out = (char *) malloc(len);
+	if (out == NULL)
+		return NULL;
+	if (!CFStringGetCString(s, out, len, kCFStringEncodingUTF8)) {
+		free(out);
+		return NULL;
+	}
+	return out;
+}
+
 // Get a device's UID as an owned CFStringRef, or NULL on failure.  The caller
 // is responsible for CFRelease()ing the result.
 static CFStringRef device_uid(AudioDeviceID devid) {
@@ -339,16 +357,32 @@ void GetDevices() {
 		// On macOS there is no useful separate description, so reuse the name
 		// (truncated) as the description.
 		dev->desc = strdup(dev->name);
-		dev->alias = NULL;  // No numeric-alias scheme on macOS.
 		dev->capture = (inch > 0);
 		dev->playback = (outch > 0);
 
 		// Record the device id and UID in the parallel map at the same index.
+		CFStringRef uidcf = device_uid(devid);
 		if (devindex < MAX_AUDIO_DEVICES) {
 			deviceIDs[devindex] = devid;
-			deviceUIDs[devindex] = device_uid(devid);  // owned, may be NULL
+			deviceUIDs[devindex] = uidcf;  // owned CFStringRef, may be NULL
 			if (devindex + 1 > deviceMapLen)
 				deviceMapLen = devindex + 1;
+		}
+		// Expose the CoreAudio UID (stable per-instance identifier) as the
+		// device alias.  When macOS surfaces multiple devices sharing the
+		// same friendly name — e.g. three USB Audio CODEC radio interfaces
+		// from the same vendor — the friendly name alone is ambiguous and
+		// FindAudioDevice()'s exact-name match picks whichever device happens
+		// to be enumerated first.  Populating alias with the UID lets a host
+		// program that already knows the UID (via CoreAudio's own APIs) pass
+		// that UID as the device string, and FindAudioDevice's name-or-alias
+		// exact match will then bind the correct device.  Legacy callers
+		// passing only the friendly name are unaffected.
+		dev->alias = cfstring_to_utf8(uidcf);
+		if (dev->alias != NULL && strlen(dev->alias) > (DEVSTRSZ - 1)) {
+			// Truncate to DEVSTRSZ - 1 like name/desc for consistency with
+			// FindAudioDevice's DEVSTRSZ-bounded compare.
+			dev->alias[DEVSTRSZ - 1] = '\0';
 		}
 		free(name);
 	}


### PR DESCRIPTION
## Summary

Adds a small macOS backend change to `GetDevices()` so that a host program can pass the CoreAudio device UID as the device string on the CLI (or via `SETPLAYBACK`/`SETCAPTURE`) and have ardopcf bind to that specific device.

The current behaviour, unchanged for callers passing a friendly name, is `FindAudioDevice()`'s exact-name match followed by a case-insensitive substring match against the description.  When macOS surfaces multiple audio devices sharing the same friendly name — e.g. three USB Audio CODEC radio interfaces from the same vendor, distinguishable only by the USB serial embedded in the CoreAudio device UID — the name-only paths land on whichever entry `AudioDevices[]` enumerated first.  A host program that has queried CoreAudio directly and knows the UID of the specific device it wants to bind had no way to communicate that intent through the CLI.

The change: populate `DeviceInfo.alias` with the CoreAudio device UID (freshly-allocated UTF-8 C string, truncated to `DEVSTRSZ - 1`) during `GetDevices()` on macOS.  `FindAudioDevice()`'s existing name-or-alias exact-match branch then binds by UID when the host passes the UID as the device string.  The name-match branch runs first, so UID matching only kicks in as a fallback when the caller passes something that isn't a name — preserving the existing behaviour for every current caller.

## What this fixes

Discovered in field-testing on a macOS host with three concurrent Burr-Brown-from-TI USB Audio CODEC interfaces (typical Icom/Yaesu/Kenwood USB codecs plugged into the same laptop).  All three enumerate as `USB Audio CODEC`, with the same manufacturer.  Only the USB serial embedded in the CoreAudio UID (`AppleUSBAudioEngine:Burr-Brown from TI:USB Audio CODEC:141100:2` vs `...:142100:2`) distinguishes them.  Pre-fix, `ardopcf 8515 "USB Audio CODEC" "USB Audio CODEC"` deterministically opens whichever CODEC enumerates first — often not the one wired to the intended radio's audio interface.  Post-fix, passing the full CoreAudio UID as the device string binds the correct device.

## Alternative considered

Extending the CLI with new `--capture-uid` / `--playback-uid` flags would achieve the same end but requires a larger change (arg parsing, help text, host-command additions).  Overloading the existing device string via `DeviceInfo.alias` is a minimal delta that reuses `FindAudioDevice()`'s existing exact-match logic — the same mechanism the Linux side uses for ALSA's `plughw:CARD=X` alias pattern.

## Backwards compatibility

- The `alias` field was `NULL` on macOS prior to this change, so no existing user of the alias code path is affected.
- Callers passing a friendly device name continue to hit the name-match branch first, unchanged.
- The `desc` field is unchanged (still equals `name` on macOS).
- No new build dependencies; the UID conversion uses `CFStringGetCString` which is already linked via `CoreFoundation`.

## Tested

- Native `make` build on Apple Silicon (macOS 26.5, Xcode CLT).  Binary size and Mach-O linkage unchanged besides the added function.
- Bench-tested against three concurrent USB CODEC interfaces: pre-fix reproduces the "opens the wrong CODEC" behaviour; post-fix binds the specific requested UID.
- Legacy behaviour: `ardopcf 8515 "USB Audio CODEC" "USB Audio CODEC"` still opens the first-enumerated CODEC (name match runs first) — verified no change.
- Non-macOS builds untouched: change is confined to `src/macos/CoreAudio.c` and does not affect the Linux ALSA or Windows Waveform paths.

## One-line summary for changelog

- `macos`: allow selecting an audio device by its CoreAudio UID (as `DeviceInfo.alias`) so that multiple devices sharing the same friendly name can be disambiguated from the CLI or host commands.
